### PR TITLE
update query builder to consider null province

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Update query builder to check for null province input before adding the province clause [#15](https://github.com/Shopify/atlas_engine/pull/15)
 - Update datastore to load the country profile with locale, and update Saudi Arabia to use normalized components instead of the normalizer class [#13](https://github.com/Shopify/atlas_engine/pull/13)
 
 

--- a/app/countries/atlas_engine/ch/country_profile.yml
+++ b/app/countries/atlas_engine/ch/country_profile.yml
@@ -1,6 +1,7 @@
 id: CH
 validation:
   enabled: true
+  has_provinces: false
   default_matching_strategy: local
   index_locales:
     - de

--- a/app/models/atlas_engine/address_validation/es/query_builder.rb
+++ b/app/models/atlas_engine/address_validation/es/query_builder.rb
@@ -152,7 +152,7 @@ module AtlasEngine
             "term" => {
               "province_code" => { "value" => address.province_code.to_s.downcase },
             },
-          } if profile.attributes.dig("validation", "has_provinces")
+          } if profile.attributes.dig("validation", "has_provinces") && address.province_code.present?
         end
       end
     end

--- a/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
+++ b/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
@@ -92,6 +92,21 @@ module AtlasEngine
           assert_equal expected_address_query("without_province_code"), query_builder.full_address_query
         end
 
+        test "#full_address_query does not return a province clause if validation.has_provinces is true but address does not have a province_code" do
+          profile_attributes = {
+            "id" => "XX",
+            "validation" => {
+              "key" => "some_value",
+              "has_provinces" => true,
+              "address_parser" => "AtlasEngine::ValidationTranscriber::AddressParserNorthAmerica",
+            },
+          }
+
+          CountryProfile.any_instance.stubs(:attributes).returns(profile_attributes)
+          query_builder = DefaultQueryBuilder.new(us_address_wo_province)
+          assert_equal expected_address_query("without_province_code"), query_builder.full_address_query
+        end
+
         test "#full_address_query returns nested city_aliases clause" do
           profile_attributes = {
             "id" => "XX",
@@ -114,6 +129,16 @@ module AtlasEngine
             address1: "123 Main Street",
             city: "San Francisco",
             province_code: "CA",
+            country_code: "US",
+            zip: "94102",
+          )
+        end
+
+        def us_address_wo_province
+          build_address(
+            address1: "123 Main Street",
+            city: "San Francisco",
+            province_code: nil,
             country_code: "US",
             zip: "94102",
           )


### PR DESCRIPTION
## Issue 
Related to work to enable validation in Switzerland, CH 

**Input** 
Via Siegfried Bieber, Val Mara, 6817, CH 

#### Expected
Found record that matches the street name and zip,
```
4519983	OA-11143516-0	it	CH	TI	NULL	NULL	NULL	NULL	---↵- Maroggia↵	NULL	6817	Via Siegfried Bieber	NULL	45.9359	8.97232	2024-01-16 19:49:34.238209	2024-01-16 19:49:34.238209	{"39": {}, "41": {}, "43": {}, "53": {}, "55": {}, "65": {}}
```

returned `city_inconsistent` concern, with suggestion Maroggia

#### Actual
Matched candidate `it,TI,,,,6810,[Isone],,Via Caserma`
returned missing_building_number,city_inconsistent,zip_inconsistent
with suggestions "Isone 6810"


## Changes 
First, updated the CH country-profile to reflect no provinces.

Next, updated the query builder such that the province clause is only included when the address.province_code is present.
This change is a **pardon on human-error**. By default `has_provinces: true`, but in some cases (such as with CH), we may forget to update it. As a result, the ES query is built with an empty province value and returns sub-optimal results. This change to query builder ensure that the province is only included in the clause if the code is available. 

<details><summary>ES query before & after</summary>

Query before:
```
{
  "query": {
    "bool": {
      "should": [
        {
          "dis_max": {
            "queries": [
              {
                "bool": {
                  "must_not": {
                    "exists": {
                      "field": "approx_building_ranges"
                    }
                  }
                }
              }
            ]
          }
        },
        {
          "dis_max": {
            "queries": [
              {
                "match": {
                  "street": {
                    "query": "Via Siegfried Bieber 65",
                    "fuzziness": "auto"
                  }
                }
              }
            ]
          }
        },
        {
          "nested": {
            "path": "city_aliases",
            "query": {
              "match": {
                "city_aliases.alias": {
                  "query": "Val Mara",
                  "fuzziness": "auto"
                }
              }
            }
          }
        },
        {
          "match": {
            "zip": {
              "query": "6817",
              "fuzziness": "auto"
            }
          }
        },
        {
          "term": {
            "province_code": {
              "value": ""
            }
          }
        }
      ],
      "minimum_should_match": 3
    }
  }
}

```


Query after: 
```
{
  "query": {
    "bool": {
      "should": [
        {
          "dis_max": {
            "queries": [
              {
                "bool": {
                  "must_not": {
                    "exists": {
                      "field": "approx_building_ranges"
                    }
                  }
                }
              }
            ]
          }
        },
        {
          "dis_max": {
            "queries": [
              {
                "match": {
                  "street": {
                    "query": "Via Siegfried Bieber 65",
                    "fuzziness": "auto"
                  }
                }
              }
            ]
          }
        },
        {
          "nested": {
            "path": "city_aliases",
            "query": {
              "match": {
                "city_aliases.alias": {
                  "query": "Val Mara",
                  "fuzziness": "auto"
                }
              }
            }
          }
        },
        {
          "match": {
            "zip": {
              "query": "6817",
              "fuzziness": "auto"
            }
          }
        }
      ],
      "minimum_should_match": 2
    }
  }
}
```
</details>

## Tophatting

<img width="1018" alt="Screenshot 2024-01-17 at 7 57 55 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/bc1ee9db-6f96-434a-8451-50f828dc28e1">
🙂 returned `city_inconsistent` concern, with suggestion Maroggia
