### PR TITLE
Revert "update query builder to consider null province"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Change the name of the active support notification to be consistent with `atlas_engine`[#18](https://github.com/Shopify/atlas_engine/pull/18)
-- Update query builder to check for null province input before adding the province clause [#15](https://github.com/Shopify/atlas_engine/pull/15)
 - Add corrector to fix encoding issues in Italy's OA data and updated Italy's mapper to not titleize the street names [#17](https://github.com/Shopify/atlas_engine/pull/17)
 
 ---

--- a/app/countries/atlas_engine/ch/country_profile.yml
+++ b/app/countries/atlas_engine/ch/country_profile.yml
@@ -1,7 +1,6 @@
 id: CH
 validation:
   enabled: true
-  has_provinces: false
   default_matching_strategy: local
   index_locales:
     - de

--- a/app/models/atlas_engine/address_validation/es/query_builder.rb
+++ b/app/models/atlas_engine/address_validation/es/query_builder.rb
@@ -152,7 +152,7 @@ module AtlasEngine
             "term" => {
               "province_code" => { "value" => address.province_code.to_s.downcase },
             },
-          } if profile.attributes.dig("validation", "has_provinces") && address.province_code.present?
+          } if profile.attributes.dig("validation", "has_provinces")
         end
       end
     end

--- a/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
+++ b/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
@@ -92,21 +92,6 @@ module AtlasEngine
           assert_equal expected_address_query("without_province_code"), query_builder.full_address_query
         end
 
-        test "#full_address_query does not return a province clause if validation.has_provinces is true but address does not have a province_code" do
-          profile_attributes = {
-            "id" => "XX",
-            "validation" => {
-              "key" => "some_value",
-              "has_provinces" => true,
-              "address_parser" => "AtlasEngine::ValidationTranscriber::AddressParserNorthAmerica",
-            },
-          }
-
-          CountryProfile.any_instance.stubs(:attributes).returns(profile_attributes)
-          query_builder = DefaultQueryBuilder.new(us_address_wo_province)
-          assert_equal expected_address_query("without_province_code"), query_builder.full_address_query
-        end
-
         test "#full_address_query returns nested city_aliases clause" do
           profile_attributes = {
             "id" => "XX",
@@ -129,16 +114,6 @@ module AtlasEngine
             address1: "123 Main Street",
             city: "San Francisco",
             province_code: "CA",
-            country_code: "US",
-            zip: "94102",
-          )
-        end
-
-        def us_address_wo_province
-          build_address(
-            address1: "123 Main Street",
-            city: "San Francisco",
-            province_code: nil,
             country_code: "US",
             zip: "94102",
           )


### PR DESCRIPTION
## Context
Reverts https://github.com/Shopify/atlas_engine/pull/15 after a significant increase in ES p95 
...

## Approach


## Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [ ] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
