### PR TITLE
Add a script to fix encoding errors in the italian source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change the name of the active support notification to be consistent with `atlas_engine`[#18](https://github.com/Shopify/atlas_engine/pull/18)
 - Update query builder to check for null province input before adding the province clause [#15](https://github.com/Shopify/atlas_engine/pull/15)
 - Add corrector to fix encoding issues in Italy's OA data and updated Italy's mapper to not titleize the street names [#17](https://github.com/Shopify/atlas_engine/pull/17)
+- Add a script to fix encoding errors in the italian source file [#24](https://github.com/Shopify/atlas_engine/pull/24)
 
 ---
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "thor", require: false
   gem "pry"
   gem "pry-byebug"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,7 @@ DEPENDENCIES
   sorbet
   sprockets-rails
   tapioca
+  thor
   webmock
 
 BUNDLED WITH

--- a/bin/fix_italy_geojson
+++ b/bin/fix_italy_geojson
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+ENV['BUNDLE_GEMFILE'] = File.absolute_path(File.join(__dir__, '../Gemfile'))
+ENV['RAILS_ENV'] ||= 'development'
+
+require 'rubygems'
+require 'bundler/setup'
+require 'thor'
+require 'zlib'
+require 'json'
+
+module FixItalyGeojson
+  class Executable < Thor
+
+    def self.exit_on_failure?
+      true
+    end
+
+    desc "reencode", "Deflate the compressed geojson file, reencode it, and write out a new copy"
+    long_desc <<~LONGDESC
+      Example usage:
+
+        bin/fix_italy_geojson reencode it.countrywide.geojson.gz
+    LONGDESC
+    def reencode(geojson_path)
+      raise ArgumentError, "Must provide a path to a geojson.gz file" unless geojson_path.end_with?(".geojson.gz")
+
+      fixed_geojson_path = geojson_path.gsub(".geojson.gz", "-reencoded.geojson.gz")
+
+      Zlib::GzipWriter.open(fixed_geojson_path) do |gz|
+        Zlib::GzipReader.new( Pathname.new(geojson_path).open("rb"))
+          .each
+          .lazy
+          .filter_map do |line|
+            line.force_encoding("iso-8859-1").unpack('U*').pack('C*').force_encoding('utf-8')
+          rescue Encoding::UndefinedConversionError => e
+            nil
+          end
+          .each do |line|
+            gz.write line
+          end
+        end
+    end
+  end
+end
+
+FixItalyGeojson::Executable.start(ARGV)


### PR DESCRIPTION
## Context
OpenAddress' `it/countrywide` address source file for Italy contains many malformed street and city names, caused by improper encoding in their data ingestion script. There is a longstanding issue catalogued [here](https://github.com/openaddresses/openaddresses/issues/4994).

## Approach
After trying several combinations of `force_encode`-ing and `encode`-ing between and _iso-8859-1_ and _UTF-8_, we found that this works:

```ruby
line.force_encoding("iso-8859-1").unpack('U*').pack('C*').force_encoding('utf-8')
```

I wrote a script to extract, reencode, and compress a geojson.gz file.
```
bin/fix_italy_geojson reencode /Users/rochlefebvre/Downloads/it.countrywide.sample.geojson.gz
```

## Testing
### Street values before and after
![image](https://github.com/Shopify/atlas_engine/assets/33674553/2a502114-eba7-4f1f-927f-72c89d8c6d5a)
![image](https://github.com/Shopify/atlas_engine/assets/33674553/8d39fd0c-1ee3-4448-8ef3-8daa3ddc3e2e)

### City value before and after
<img width="50%" src="https://github.com/Shopify/atlas_engine/assets/33674553/f60fad57-b9e2-4998-abb1-61e1f7244496"/>
<img width="50%" src="https://github.com/Shopify/atlas_engine/assets/33674553/da04fe31-a208-489b-9833-a54e1783f9ef"/>

All 13,903,309 rows were preserved in the reencoded copy.

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [ ] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
