### PR TITLE
Update Italy to use custom parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change the name of the active support notification to be consistent with `atlas_engine`[#18](https://github.com/Shopify/atlas_engine/pull/18)
 - Add corrector to fix encoding issues in Italy's OA data and updated Italy's mapper to not titleize the street names [#17](https://github.com/Shopify/atlas_engine/pull/17)
 - Add a script to fix encoding errors in the italian source file [#24](https://github.com/Shopify/atlas_engine/pull/24)
+- Update IT to use DK address parser [#25](https://github.com/Shopify/atlas_engine/pull/25)
 
 ---
 

--- a/app/countries/atlas_engine/it/country_profile.yml
+++ b/app/countries/atlas_engine/it/country_profile.yml
@@ -2,6 +2,7 @@ id: IT
 validation:
   enabled: true
   default_matching_strategy: es
+  address_parser: AtlasEngine::Dk::ValidationTranscriber::AddressParser
 ingestion:
   open_address:
     feature_mapper: AtlasEngine::It::AddressImporter::OpenAddress::Mapper


### PR DESCRIPTION
## Context
Part of https://github.com/Shopify/address/issues/2212
Partially fixes https://github.com/Shopify/address/issues/2439

We are selecting the wrong candidate in the following case:
<img width="1288" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/2b9afc4b-e06e-4f6a-b611-a49ce70f89ed">

This is because Italy is not yet set up to use an address parser.

## Approach

Updated the IT country profile to use the DK parser since they use the same address format.

## Testing

🎩 
<img width="1256" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/ca7246c8-9e27-45de-993e-50145ab824b0">


## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
