### PR TITLE
update CH country profile with parser and has_provinces:false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Update CH country profile with an address parser and has_provinces:false[#28](https://github.com/Shopify/atlas_engine/pull/28)
 - Add maintenance task migrations to dummy app [#30](https://github.com/Shopify/atlas_engine/pull/30)
 - Update datastore to load the country profile with locale, and update Saudi Arabia to use normalized components instead of the normalizer class [#23](https://github.com/Shopify/atlas_engine/pull/23)
 - Change the name of the active support notification to be consistent with `atlas_engine`[#18](https://github.com/Shopify/atlas_engine/pull/18)

--- a/app/countries/atlas_engine/ch/country_profile.yml
+++ b/app/countries/atlas_engine/ch/country_profile.yml
@@ -2,6 +2,8 @@ id: CH
 validation:
   enabled: true
   default_matching_strategy: local
+  has_provinces: false
+  address_parser: AtlasEngine::De::ValidationTranscriber::AddressParser
   index_locales:
     - de
     - fr

--- a/app/countries/atlas_engine/ch/locales/de/country_profile.yml
+++ b/app/countries/atlas_engine/ch/locales/de/country_profile.yml
@@ -2,7 +2,6 @@ id: CH_DE
 ingestion:
   data_mapper: AtlasEngine::AddressValidation::Es::DataMappers::DecompoundingDataMapper
 validation:
-  address_parser: AtlasEngine::De::ValidationTranscriber::AddressParser
   normalized_components:
   - region2
   - region3

--- a/app/countries/atlas_engine/ch/locales/fr/country_profile.yml
+++ b/app/countries/atlas_engine/ch/locales/fr/country_profile.yml
@@ -1,0 +1,3 @@
+id: CH_FR
+validation:
+  address_parser: AtlasEngine::Ch::Locales::Fr::ValidationTranscriber::AddressParser

--- a/app/countries/atlas_engine/ch/locales/fr/validation_transcriber/address_parser.rb
+++ b/app/countries/atlas_engine/ch/locales/fr/validation_transcriber/address_parser.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+# French address in Switzerland can be written in the following ways:
+# 1. thoroughfare type[ ]Thoroughfare name[ ]number
+# 2. number[ ]thoroughfare type[ ]Thoroughfare name
+
+module AtlasEngine
+  module Ch
+    module Locales
+      module Fr
+        module ValidationTranscriber
+          class AddressParser < AtlasEngine::ValidationTranscriber::AddressParserBase
+            private
+
+            sig { returns(T::Array[Regexp]) }
+            def country_regex_formats
+              @country_regex_formats ||=
+                [
+                  /^#{BUILDING_NUM}?\s*#{STREET_NO_COMMAS}$/o,
+                  /^#{STREET_NO_COMMAS}?\s*#{BUILDING_NUM}$/o,
+                ]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/ch/locales/fr/validation_transcriber/address_parser_test.rb
+++ b/test/countries/atlas_engine/ch/locales/fr/validation_transcriber/address_parser_test.rb
@@ -1,0 +1,45 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AtlasEngine
+  module Ch
+    module Locales
+      module Fr
+        class AddressParserTest < ActiveSupport::TestCase
+          include ValidationTranscriber
+
+          test "Swiss addresses written in French" do
+            [
+              # Unit number preceeding street
+              [:ch, "798 Route de la Gruvaz", [{ building_num: "798", street: "Route de la Gruvaz" }]],
+              # Unit number following street
+              [:ch, "Rue Saint-Germain 3", [{ building_num: "3", street: "Rue Saint-Germain" }]],
+            ].each do |country_code, input, expected|
+              check_parsing(country_code, input, nil, expected)
+            end
+          end
+
+          private
+
+          def check_parsing(country_code, address1, address2, expected, components = nil)
+            components ||= {}
+            components.merge!(country_code: country_code.to_s.upcase, address1: address1, address2: address2)
+            address = AddressValidation::Address.new(**components)
+
+            actual = ValidationTranscriber::AddressParser.new(address: address).parse
+
+            assert(
+              expected.to_set.subset?(actual.to_set),
+              "For input ( address1: #{address1.inspect}, address2: #{address2.inspect} )\n\n " \
+                "#{expected.inspect} \n\n" \
+                "Must be included in: \n\n" \
+                "#{actual.inspect}",
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/models/atlas_engine/address_validation/es/validators/full_address_test.rb
+++ b/test/models/atlas_engine/address_validation/es/validators/full_address_test.rb
@@ -135,7 +135,7 @@ module AtlasEngine
           end
 
           test "picks the best candidate for a multi-locale country" do
-            @address = address(country_code: "CH", city: "Brn")
+            @address = address(address1: "Mövenweg", zip: "8597", country_code: "CH", city: "Brn", province_code: "")
             ch_session = AddressValidation::Session.new(address: @address)
 
             ch_session.datastore(locale: "de").city_sequence = Token::Sequence.from_string(@address.city)
@@ -242,11 +242,12 @@ module AtlasEngine
 
           private
 
-          def address(address1: "123 Main Street", zip: "94102", country_code: "US", city: "San Francisco")
+          def address(address1: "123 Main Street", zip: "94102", country_code: "US", city: "San Francisco",
+            province_code: "CA")
             build_address(
               address1: address1,
               city: city,
-              province_code: "CA",
+              province_code: province_code,
               country_code: country_code,
               zip: zip,
             )


### PR DESCRIPTION
## Context
Switzerland does not have provinces, and needs an address parser. 

The first address line depends on the written language. 
DE:
-  Thoroughfare name thoroughfare type[ ]number

IT: 
- thoroughfare type[ ]Thoroughfare name[ ]number

FR: 
- thoroughfare type[ ]Thoroughfare name[ ]number, OR
-  number[ ]thoroughfare type[ ]Thoroughfare name

[ref](https://www.grcdi.nl/gsb/switzerland.html#HCE2DE031DE9CD774B8664947EC4270D4CA13DF78035A2AA2ASwitzerlandA20A2DA20A5BA5BAddressesA5DA5DA2AA2A00100401201501801B01E02A02D030033)


## Approach
Update the top-level country parser to indicate no provinces. 

Update the top-level country profile to use the German address parser. This works for the DE and IT written addresses, where the building number follows the street. 

Added an address parser for CH_FR, where the building number can either preced OR follow the street. 


## Testing
Tested against IT, DE, and FR address formats for Switzerlands. The parsing results look good :) 

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
