### PR TITLE
Remove the empty-building-clause from the full address query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Remove the empty building clause from the full address query [#31](https://github.com/Shopify/atlas_engine/pull/31)
 - Update italy re-encoding script to discard malformed lines [#33](https://github.com/Shopify/atlas_engine/pull/33)
 - Add maintenance task migrations to dummy app [#30](https://github.com/Shopify/atlas_engine/pull/30)
 - Update CH country profile with an address parser and has_provinces:false[#28](https://github.com/Shopify/atlas_engine/pull/28)

--- a/test/fixtures/atlas_engine/address_validation/address_query_mx.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_mx.json
@@ -6,21 +6,6 @@
           "dis_max": {
             "queries": [
               {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "dis_max": {
-            "queries": [
-              {
                 "match": {
                   "street": {
                     "query": "Avenida Justo Sierra Méndez 491",
@@ -60,7 +45,7 @@
           }
         }
       ],
-      "minimum_should_match": 3
+      "minimum_should_match": 2
     }
   }
 }

--- a/test/fixtures/atlas_engine/address_validation/address_query_nested_city_aliases_one_city_field.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_nested_city_aliases_one_city_field.json
@@ -11,15 +11,6 @@
                     "value": 123
                   }
                 }
-              },
-              {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
               }
             ]
           }

--- a/test/fixtures/atlas_engine/address_validation/address_query_us.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us.json
@@ -11,15 +11,6 @@
                     "value": 123
                   }
                 }
-              },
-              {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
               }
             ]
           }

--- a/test/fixtures/atlas_engine/address_validation/address_query_us_a2.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us_a2.json
@@ -11,15 +11,6 @@
                       "value": 123
                   }
                 }
-              },
-              {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
               }
             ]
           }

--- a/test/fixtures/atlas_engine/address_validation/address_query_us_compound_street_name.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us_compound_street_name.json
@@ -11,15 +11,6 @@
                     "value": 18108
                   }
                 }
-              },
-              {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
               }
             ]
           }

--- a/test/fixtures/atlas_engine/address_validation/address_query_us_missing.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us_missing.json
@@ -6,21 +6,6 @@
           "dis_max": {
             "queries": [
               {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "dis_max": {
-            "queries": [
-              {
                 "match": {
                   "street": { "query": "Main Street", "fuzziness": "auto" }
                 }
@@ -49,7 +34,7 @@
           }
         }
       ],
-      "minimum_should_match": 3
+      "minimum_should_match": 2
     }
   }
 }

--- a/test/fixtures/atlas_engine/address_validation/address_query_with_fractional_building_number.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_with_fractional_building_number.json
@@ -11,15 +11,6 @@
                     "value": 123
                   }
                 }
-              },
-              {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
               }
             ]
           }

--- a/test/fixtures/atlas_engine/address_validation/address_query_with_under_4_clauses.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_with_under_4_clauses.json
@@ -11,15 +11,6 @@
                     "value": 123
                   }
                 }
-              },
-              {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
               }
             ]
           }

--- a/test/fixtures/atlas_engine/address_validation/address_query_without_building_number.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_without_building_number.json
@@ -6,21 +6,6 @@
           "dis_max": {
             "queries": [
               {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "dis_max": {
-            "queries": [
-              {
                 "match": {
                   "street": {
                     "query": "Main Street",
@@ -68,7 +53,7 @@
           }
         }
       ],
-      "minimum_should_match": 3
+      "minimum_should_match": 2
     }
   }
 }

--- a/test/fixtures/atlas_engine/address_validation/address_query_without_province_code.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_without_province_code.json
@@ -11,15 +11,6 @@
                     "value": 123
                   }
                 }
-              },
-              {
-                "bool": {
-                  "must_not": {
-                    "exists": {
-                      "field": "approx_building_ranges"
-                    }
-                  }
-                }
               }
             ]
           }

--- a/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
+++ b/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
@@ -26,7 +26,7 @@ module AtlasEngine
           assert_equal expected_address_query("mx"), query_builder.full_address_query
         end
 
-        test "#full_address_query returns a valid query for an input missing a building number" do
+        test "#full_address_query returns a query without a building number clause where there is no building number" do
           query_builder = DefaultQueryBuilder.new(missing_number_address)
           assert_equal expected_address_query("us_missing"), query_builder.full_address_query
         end


### PR DESCRIPTION
## Context
Noticed while working on Switzerland that the full address query always contains the following condition
```
{
   "bool": {
      "must_not": {
          "exists": {
                "field": "approx_building_ranges"
          }
     }
}
```

This gives a higher score to documents that do not have an approx_building_ranges value. 

This is undesirable in countries that:
- do not have a parser setup (was the case for CH) 
- have a format where the street number follows the street name 
- have poor street number coverage 

## Approach
Remove the must_not clause on building number. 

## Expected impact on production 
TL;DR A slight increase in validation request time. 

We will see ES query times increase in the cases when the client inputs a valid address without a building number.
- **before**: The full address query has a minimum_should_match: 3; the query would rank documents with against the empty building number clause.
- **after**: The full address query will have minimum_should_match: 2; this will increase the ES query time.

## Testing

benchmarking before: 

<img width="598" alt="Screenshot 2024-01-19 at 5 14 38 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/8a5c43e9-b20b-48f8-9447-0da8438b5c64">

benchmarking after (no change): 
<img width="594" alt="Screenshot 2024-01-22 at 11 48 58 AM" src="https://github.com/Shopify/atlas_engine/assets/145736265/659ae573-4dfa-44be-896d-5347a35b82af">
🟢 `% of known invalid addresses (with CORRECT suggestion)` increased to 79.8%
🟢 `% of known invalid addresses (with no suggestion)` decreased to 13.1%


## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
