### PR TITLE
add city alias for BM

### DIFF
--- a/app/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector.rb
+++ b/app/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector.rb
@@ -13,6 +13,7 @@ module AtlasEngine
               BM_PARISH_AND_CITY_NAMES = {
                 "Devonshire" => "Devonshire Parish",
                 "Hamilton" => "Hamilton Parish",
+                "City of Hamilton" => "Hamilton",
                 "Paget" => "Paget Parish",
                 "Pembroke" => "Pembroke Parish",
                 "Sandys" => "Sandys Parish",

--- a/test/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector_test.rb
+++ b/test/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector_test.rb
@@ -31,7 +31,7 @@ module AtlasEngine
               bm_cities = [
                 {
                   input: ["City of Hamilton"],
-                  expected: ["City of Hamilton"], # no aliases
+                  expected: ["City of Hamilton", "Hamilton"],
                 },
                 {
                   input: ["Hamilton"],
@@ -72,6 +72,10 @@ module AtlasEngine
                 {
                   input: ["Warwick"],
                   expected: ["Warwick", "Warwick Parish"],
+                },
+                {
+                  input: ["Another City"],
+                  expected: ["Another City"], # no aliases
                 },
               ]
 


### PR DESCRIPTION
## Context
In some cases, people will write "Hamilton" instead of "City of Hamilton". 

Adding this alias. 

## Approach
<!-- Describe your solution, why this approach was chosen, and what the alternatives/impacts may be -->

...

## Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [ ] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
