### PR TITLE
Perform comparisons on all address components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Update Bermuda city alias assignment and synonyms [#43](https://github.com/Shopify/atlas_engine/pull/43)
 - Remove unused validation.city_fields param from country profiles [#42](https://github.com/Shopify/atlas_engine/pull/42)
+- Update CandidateResult to factor in all address components in comparisons [#40](https://github.com/Shopify/atlas_engine/pull/40)
 - Hook up docker compose to dockerfile that installs analysis-icu plugin in dockerized es [#32](https://github.com/Shopify/atlas_engine/pull/32)
 - Add matching_strategy param to logs [#36](https://github.com/Shopify/atlas_engine/pull/36)
 - Add custom parser and query builder for CZ to handle addresses with no street names [#34](https://github.com/Shopify/atlas_engine/pull/34)


### PR DESCRIPTION
## Context

Resolves https://github.com/Shopify/address/issues/2466 and https://github.com/Shopify/address/issues/2461

For some countries, like Italy, we are selecting candidates that only match the input address on the province, and are still returning suggestions (see above issue for examples). This is because the threshold for unmatched components in order to return `address_unknown` concern is 2, and in these cases the unmatched components are `[:zip, :city]`. When the matching strategy is `ES`, we do not perform street comparisons when building the candidate result, and we don't consider street when generating the unmatched components. 

## Approach

Separate the concepts of components to compare vs components to validate. Components to compare include all components used by the given country. Components to validate consider more factors, like the matching strategy, and determine which components should have concerns & suggestions.

New behaviour: street will now be able to influence whether or not we return an `address_unknown` concern, even when matching strategy is `ES`. Consequence: This will affect countries that have poor address parsing, resulting in more address_unknown concerns.

## Testing

Before:
<img width="1488" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/7097a1e4-2d8b-4cd7-8ff8-d9f49a3897aa">

After:
<img width="1726" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/2282c0ce-7a71-4b11-bfac-5d9582395ae1">

Benchmarking with the dev_tagged suite shows no changes when compared with staging (I used the proxy in order to have the same data as staging)
<img width="774" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/5abef29c-03f9-4e96-ae98-74eb95c3e140">

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
