### PR TITLE
Cleanup; remove unused city_fields param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Remove unused validation.city_fields param from country profiles [#42](https://github.com/Shopify/atlas_engine/pull/42)
 - Hook up docker compose to dockerfile that installs analysis-icu plugin in dockerized es [#32](https://github.com/Shopify/atlas_engine/pull/32)
 - Add matching_strategy param to logs [#36](https://github.com/Shopify/atlas_engine/pull/36)
 - Add custom parser and query builder for CZ to handle addresses with no street names [#34](https://github.com/Shopify/atlas_engine/pull/34)

--- a/app/countries/atlas_engine/us/country_profile.yml
+++ b/app/countries/atlas_engine/us/country_profile.yml
@@ -2,8 +2,6 @@ id: US
 validation:
   enabled: true
   default_matching_strategy: es_street
-  city_fields:
-    - city_aliases
   address_parser: AtlasEngine::ValidationTranscriber::AddressParserNorthAmerica
 ingestion:
   settings:

--- a/db/data/country_profiles/default.yml
+++ b/db/data/country_profiles/default.yml
@@ -11,8 +11,6 @@ validation:
   has_provinces: true
   index_locales: []
   default_matching_strategy: local
-  city_fields:
-    - city_aliases
   normalized_components: []
   exclusions: {}
   partial_postal_code_range_for_length: {}

--- a/test/models/atlas_engine/country_profile_test.rb
+++ b/test/models/atlas_engine/country_profile_test.rb
@@ -81,7 +81,6 @@ module AtlasEngine
       assert_equal("some_value", profile.validation.key)
       assert_equal(false, profile.validation.enabled)
       assert_equal("local", profile.validation.default_matching_strategy)
-      assert_equal(["city_aliases"], profile.validation.city_fields)
       assert_equal([], profile.validation.normalized_components)
       assert_equal({}, profile.validation.exclusions)
       assert_equal({}, profile.validation.partial_postal_code_range_for_length)


### PR DESCRIPTION
## Context
The city_fields param was introduced as a way to indicate the field to search when constructing the `city_clause` in the Es::QueryBuilder. With the default being city_aliases.

For some time, the city_clause query has been updated to always use the city_aliases field. This country profiles param is no longer necessary. 

https://github.com/Shopify/atlas_engine/blob/7088d418ff26fbffad45cdbffc5425fe8a574066/app/models/atlas_engine/address_validation/es/query_builder.rb#L135-L146

## Approach
Remove the unused param 

## Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
