### PR TITLE
Update BM aliases and synonyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Update Bermuda city alias assignment and synonyms [#43](https://github.com/Shopify/atlas_engine/pull/43)
 - Remove unused validation.city_fields param from country profiles [#42](https://github.com/Shopify/atlas_engine/pull/42)
 - Hook up docker compose to dockerfile that installs analysis-icu plugin in dockerized es [#32](https://github.com/Shopify/atlas_engine/pull/32)
 - Add matching_strategy param to logs [#36](https://github.com/Shopify/atlas_engine/pull/36)

--- a/app/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector.rb
+++ b/app/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector.rb
@@ -11,22 +11,23 @@ module AtlasEngine
               extend T::Sig
 
               BM_PARISH_AND_CITY_NAMES = {
-                "Devonshire" => "Devonshire Parish",
-                "Hamilton" => "Hamilton Parish",
-                "Paget" => "Paget Parish",
-                "Pembroke" => "Pembroke Parish",
-                "Sandys" => "Sandys Parish",
-                "Smiths" => "Smiths Parish",
-                "Southampton" => "Southampton Parish",
-                "St. George's" => "St. George's Parish",
-                "Town of St. George" => "St. George",
-                "Warwick" => "Warwick Parish",
+                "City of Hamilton" => ["City of Hamilton", "Hamilton"],
+                "Devonshire" => ["Devonshire Parish", "Devonshire"],
+                "Hamilton" => ["Hamilton Parish", "Hamilton"],
+                "Paget" => ["Paget Parish", "Paget"],
+                "Pembroke" => ["Pembroke Parish", "Pembroke"],
+                "Sandys" => ["Sandys Parish", "Sandys"],
+                "Smiths" => ["Smiths Parish", "Smiths"],
+                "Southampton" => ["Southampton Parish", "Southampton"],
+                "St. George's" => ["St. George's Parish", "St. George's"],
+                "Town of St. George" => ["Town of St. George", "St. George"],
+                "Warwick" => ["Warwick Parish", "Warwick"],
               }.freeze
 
               sig { params(address: Hash).void }
               def apply(address)
                 if BM_PARISH_AND_CITY_NAMES.key?(address[:city][0])
-                  address[:city] << BM_PARISH_AND_CITY_NAMES[address[:city][0]]
+                  address[:city] = BM_PARISH_AND_CITY_NAMES[address[:city][0]]
                 end
               end
             end

--- a/app/countries/atlas_engine/bm/synonyms.yml
+++ b/app/countries/atlas_engine/bm/synonyms.yml
@@ -1,0 +1,6 @@
+street_synonyms:
+- lane, ln
+- road, rd
+- street, st
+- avenue, ave
+- drive, drv, dr

--- a/test/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector_test.rb
+++ b/test/countries/atlas_engine/bm/address_importer/corrections/open_address/city_alias_corrector_test.rb
@@ -31,11 +31,11 @@ module AtlasEngine
               bm_cities = [
                 {
                   input: ["City of Hamilton"],
-                  expected: ["City of Hamilton"], # no aliases
+                  expected: ["City of Hamilton", "Hamilton"],
                 },
                 {
                   input: ["Hamilton"],
-                  expected: ["Hamilton", "Hamilton Parish"],
+                  expected: ["Hamilton Parish", "Hamilton"],
                 },
                 {
                   input: ["Town of St. George"],
@@ -43,35 +43,39 @@ module AtlasEngine
                 },
                 {
                   input: ["St. George's"],
-                  expected: ["St. George's", "St. George's Parish"],
+                  expected: ["St. George's Parish", "St. George's"],
                 },
                 {
                   input: ["Devonshire"],
-                  expected: ["Devonshire", "Devonshire Parish"],
+                  expected: ["Devonshire Parish", "Devonshire"],
                 },
                 {
                   input: ["Paget"],
-                  expected: ["Paget", "Paget Parish"],
+                  expected: ["Paget Parish", "Paget"],
                 },
                 {
                   input: ["Pembroke"],
-                  expected: ["Pembroke", "Pembroke Parish"],
+                  expected: ["Pembroke Parish", "Pembroke"],
                 },
                 {
                   input: ["Sandys"],
-                  expected: ["Sandys", "Sandys Parish"],
+                  expected: ["Sandys Parish", "Sandys"],
                 },
                 {
                   input: ["Smiths"],
-                  expected: ["Smiths", "Smiths Parish"],
+                  expected: ["Smiths Parish", "Smiths"],
                 },
                 {
                   input: ["Southampton"],
-                  expected: ["Southampton", "Southampton Parish"],
+                  expected: ["Southampton Parish", "Southampton"],
                 },
                 {
                   input: ["Warwick"],
-                  expected: ["Warwick", "Warwick Parish"],
+                  expected: ["Warwick Parish", "Warwick"],
+                },
+                {
+                  input: ["A new Parish"],
+                  expected: ["A new Parish"], # no aliases
                 },
               ]
 


### PR DESCRIPTION
## Context
The validation responses for Bermuda show that city suggestions are returning the short-form of the municipality name, 
ex: 
```
input: 1 Harbour Vista, McKenzie Way, Bermuda

returns: city_inconsistent
suggestion: Warwick
candidate: ,,,,,WK 06,[Warwick,Warwick Parish],,Mc Kenzie Way
```

**Desired suggestion: Warwick Parish**

Why: This is because OSM stores the short names, and our system is appending the long form. 

## Approach
Switch the city assignment so the long/proper form of the municipality name (including Parish designator) is first. 

Also added the commonly used alias `Hamilton` for `City of Hamilton`. 
Note: This alias is now applied to two different municipalities in Bermuda; City of Hamilton and Hamilton Parish. These municipalities have different zip prefixes (City of Hamilton: `HM ##`, Hamilton Parish `HS|CR|FL ##`); the effect of this change is only that the system will no longer return suggestion `City of Hamilton` when the input city is `Hamilton`. 

## Testing
after: suggesting warwick parish 🎉 
<img width="1025" alt="Screenshot 2024-01-23 at 12 47 50 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/0dd60daf-a52c-40eb-9ee6-0f867a30a147">

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
