### PR TITLE
Various minor cleanup changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 !/log/.keep
 !/tmp/.keep
 
+# debugging and tooling files
+.byebug_history
+
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*
 !/tmp/pids/

--- a/app/lib/atlas_engine/validation_transcriber/address_parsings.rb
+++ b/app/lib/atlas_engine/validation_transcriber/address_parsings.rb
@@ -42,7 +42,7 @@ module AtlasEngine
 
       sig { returns(T::Array[String]) }
       def potential_building_numbers
-        parsings.pluck(:building_num).compact.uniq
+        parsings.pluck(:building_num).compact.uniq.reject { |n| n.match?(/\d{7,}/) }
       end
 
       sig { params(address_input: AddressValidation::AbstractAddress).void }

--- a/app/models/atlas_engine/address_validation/datastore_base.rb
+++ b/app/models/atlas_engine/address_validation/datastore_base.rb
@@ -20,6 +20,9 @@ module AtlasEngine
       sig { abstract.returns(T::Hash[T.untyped, T.untyped]) }
       def validation_response; end
 
+      sig { abstract.returns(CountryProfile) }
+      def country_profile; end
+
       sig { abstract.returns(ValidationTranscriber::AddressParsings) }
       def parsings; end
     end

--- a/app/models/atlas_engine/address_validation/es/query_builder.rb
+++ b/app/models/atlas_engine/address_validation/es/query_builder.rb
@@ -163,7 +163,7 @@ module AtlasEngine
             "term" => {
               "province_code" => { "value" => address.province_code.to_s.downcase },
             },
-          } if profile.attributes.dig("validation", "has_provinces")
+          } if profile.attributes.dig("validation", "has_provinces") && address.province_code.present?
         end
       end
     end

--- a/app/models/atlas_engine/country_profile_validation_subset.rb
+++ b/app/models/atlas_engine/country_profile_validation_subset.rb
@@ -44,5 +44,10 @@ module AtlasEngine
     def address_parser
       attributes.dig("address_parser").constantize
     end
+
+    sig { returns(T::Array[String]) }
+    def normalized_components
+      attributes.dig("normalized_components") || []
+    end
   end
 end

--- a/app/tasks/maintenance/atlas_engine/elasticsearch_index_create_task.rb
+++ b/app/tasks/maintenance/atlas_engine/elasticsearch_index_create_task.rb
@@ -36,7 +36,7 @@ module Maintenance
         record_count = ::AtlasEngine::PostAddress.where(address_conditions).size
         raise "No records to process for country code: #{country_code}" if record_count.zero?
 
-        repository.create_next_index(ensure_clean: true)
+        repository.create_next_index(ensure_clean: true, raise_errors: true)
 
         ::AtlasEngine::PostAddress.where(address_conditions).in_batches(of: batch_size)
       end

--- a/test/lib/validation_transcriber/address_parsings_test.rb
+++ b/test/lib/validation_transcriber/address_parsings_test.rb
@@ -58,6 +58,16 @@ module AtlasEngine
         assert_equal ["123"], AddressParsings.new(address_input: partial_address).potential_building_numbers
       end
 
+      test "#potential_building_numbers ignores long numeric values" do
+        partial_address = build_address(
+          address1: "12345678901 Main St",
+          address2: "Apt 1",
+          country_code: "CA",
+        )
+
+        assert_equal [], AddressParsings.new(address_input: partial_address).potential_building_numbers
+      end
+
       test "unparsable addresses are logged" do
         address_hash = {
           address1: "Elgin St",

--- a/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
+++ b/test/models/atlas_engine/address_validation/es/default_query_builder_test.rb
@@ -92,6 +92,22 @@ module AtlasEngine
           assert_equal expected_address_query("without_province_code"), query_builder.full_address_query
         end
 
+        test "#full_address_query does not return a province clause if validation.has_provinces is true /
+          but address does not have a province_code" do
+          profile_attributes = {
+            "id" => "XX",
+            "validation" => {
+              "key" => "some_value",
+              "has_provinces" => true,
+              "address_parser" => "AtlasEngine::ValidationTranscriber::AddressParserNorthAmerica",
+            },
+          }
+
+          CountryProfile.any_instance.stubs(:attributes).returns(profile_attributes)
+          query_builder = DefaultQueryBuilder.new(us_address_wo_province)
+          assert_equal expected_address_query("without_province_code"), query_builder.full_address_query
+        end
+
         test "#full_address_query returns nested city_aliases clause" do
           profile_attributes = {
             "id" => "XX",
@@ -114,6 +130,16 @@ module AtlasEngine
             address1: "123 Main Street",
             city: "San Francisco",
             province_code: "CA",
+            country_code: "US",
+            zip: "94102",
+          )
+        end
+
+        def us_address_wo_province
+          build_address(
+            address1: "123 Main Street",
+            city: "San Francisco",
+            province_code: nil,
             country_code: "US",
             zip: "94102",
           )

--- a/test/tasks/maintenance/atlas_engine/elasticsearch_index_create_task_test.rb
+++ b/test/tasks/maintenance/atlas_engine/elasticsearch_index_create_task_test.rb
@@ -89,7 +89,7 @@ module Maintenance
         task = Maintenance::AtlasEngine::ElasticsearchIndexCreateTask.new
         task.attributes = { country_code: "US", province_codes: "IL", repository: @repository }
 
-        @repository.expects(:create_next_index).with(ensure_clean: true).returns(true)
+        @repository.expects(:create_next_index).with(ensure_clean: true, raise_errors: true).returns(true)
 
         task.collection
       end


### PR DESCRIPTION
## Context
Ground work for supporting sequence comparisons having extra/optional tokens, with some additional quality-of-life changes (free of charge).

## Approach

### Do not include especially long building numbers in ES query
We map `approx_building_ranges` as an integer range.  If a query contains a value that does not fit inside an integer, ES returns an error.  I have encountered phone numbers in address1/2 that were leading to this problem.

I added a fairly generous cap of 7 digits.

### Expose `country_profile` method on `Datastore`
Datastore is one of the few classes that knows about the validation locale. I would like to add some functionality in code that has a datastore reference, but is otherwise quite far removed from the locale. Calling `datastore.country_profile` is a bit lame, but we don't have appealing alternatives in the short term.

I'm starting to think about storing validation locale as a thread local variable... but that needs thought.

### Only add `province_code` query clause if the given address has one
Some countries may accept provinces in their address as optional params. When `CountryProfile.validation.has_provinces` is true but the input address does not have a province, we should not add `province_code -- ""` to the ES query.

Taken from https://github.com/Shopify/atlas_engine/pull/26/files#diff-fb719617bf4577203b03e7c87a590f4d41fe8986ce0929a56b60f03d1b05acaa (Thanks @DominiqueFlaaa)

### Misc changes
- Reraise server errors when creating a new index
- Add .byebug_history to .gitignore

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
