### PR TITLE
Improve indexing for poland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Improve indexing for Poland [#56](https://github.com/Shopify/atlas_engine/pull/56)
 - Configure sequence comparison policy for South Korea [#58](https://github.com/Shopify/atlas_engine/pull/58)
 - Configurable sequence comparison policy [#54](https://github.com/Shopify/atlas_engine/pull/54)
 - Emit StatsD validation metric when address_unknown concern is returned [#55](https://github.com/Shopify/atlas_engine/pull/55)

--- a/app/countries/atlas_engine/pl/address_importer/corrections/open_address/city_corrector.rb
+++ b/app/countries/atlas_engine/pl/address_importer/corrections/open_address/city_corrector.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Pl
+    module AddressImporter
+      module Corrections
+        module OpenAddress
+          class CityCorrector
+            class << self
+              extend T::Sig
+
+              sig { params(address: Hash).void }
+              def apply(address)
+                if address[:city] == ["Warszawa"]
+                  address[:city] << "Warsaw"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/countries/atlas_engine/pl/address_importer/corrections/open_address/empty_street_corrector.rb
+++ b/app/countries/atlas_engine/pl/address_importer/corrections/open_address/empty_street_corrector.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Pl
+    module AddressImporter
+      module Corrections
+        module OpenAddress
+          class EmptyStreetCorrector
+            class << self
+              extend T::Sig
+
+              sig { params(address: Hash).void }
+              def apply(address)
+                if address[:street] == "" && address[:city].present?
+                  # Many smaller rural towns in Poland don't have street names. Mailing addresses are
+                  # often expressed as
+                  # address1: <town name> <building number>
+                  # city: <town name> OR <nearest postal town>
+                  # postal_code: <postal code>
+                  #
+                  # The OpenAddresses dataset does not currently include county/postal town info.
+                  address[:street] = Array(address[:city]).first
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/countries/atlas_engine/pl/address_importer/corrections/open_address/postal_code_placeholder_corrector.rb
+++ b/app/countries/atlas_engine/pl/address_importer/corrections/open_address/postal_code_placeholder_corrector.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Pl
+    module AddressImporter
+      module Corrections
+        module OpenAddress
+          class PostalCodePlaceholderCorrector
+            class << self
+              extend T::Sig
+
+              sig { params(address: Hash).void }
+              def apply(address)
+                if address[:zip] == "00-000"
+                  address[:zip]  = nil
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/countries/atlas_engine/pl/country_profile.yml
+++ b/app/countries/atlas_engine/pl/country_profile.yml
@@ -1,4 +1,10 @@
 id: PL
+ingestion:
+  correctors:
+    open_address:
+      - AtlasEngine::Pl::AddressImporter::Corrections::OpenAddress::CityCorrector
+      - AtlasEngine::Pl::AddressImporter::Corrections::OpenAddress::PostalCodePlaceholderCorrector
+      - AtlasEngine::Pl::AddressImporter::Corrections::OpenAddress::EmptyStreetCorrector
 validation:
   address_parser: AtlasEngine::Pl::ValidationTranscriber::AddressParser
   enabled: true

--- a/app/countries/atlas_engine/pl/synonyms.yml
+++ b/app/countries/atlas_engine/pl/synonyms.yml
@@ -1,0 +1,12 @@
+street_synonyms:
+## street suffixes
+- aleja, al # avenue
+- osiedle, os # housing estate
+- plac, pl # square
+- ulica, ul # street
+## titles
+- święta, św # saint (feminine)
+- świętego, św # saint
+- święty, św # saint (masculine)
+city_synonyms:
+- wielkopolska, wlkp # Greater Poland

--- a/test/countries/atlas_engine/pl/address_importer/corrections/open_address/city_corrector_test.rb
+++ b/test/countries/atlas_engine/pl/address_importer/corrections/open_address/city_corrector_test.rb
@@ -1,0 +1,62 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AtlasEngine
+  module Pl
+    module AddressImporter
+      module Corrections
+        module OpenAddress
+          class CityCorrectorTest < ActiveSupport::TestCase
+            setup do
+              @klass = CityCorrector
+            end
+
+            test "apply appends Warsaw as city alias when city is Warszawa" do
+              input_address = {
+                source_id: "OA#9ac45faa4a783dbf",
+                locale: "PL",
+                country_code: "PL",
+                province_code: "",
+                region1: "",
+                city: ["Warszawa"],
+                suburb: nil,
+                zip: "03-938",
+                street: "Zwycięzców",
+                building_and_unit_ranges: { "40" => {} },
+              }
+
+              expected = input_address.merge({ city: ["Warszawa", "Warsaw"] })
+
+              @klass.apply(input_address)
+
+              assert_equal expected, input_address
+            end
+
+            test "apply does nothing for any other city" do
+              input_address = {
+                source_id: "OA#9ac45faa4a783dbf",
+                locale: "PL",
+                country_code: "PL",
+                province_code: "",
+                region1: "",
+                city: ["Trzebnica"],
+                suburb: nil,
+                zip: "55-100",
+                street: "Wrocławska",
+                building_and_unit_ranges: { "8D" => {} },
+              }
+
+              expected = input_address
+
+              @klass.apply(input_address)
+
+              assert_equal expected, input_address
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/pl/address_importer/corrections/open_address/empty_street_corrector_test.rb
+++ b/test/countries/atlas_engine/pl/address_importer/corrections/open_address/empty_street_corrector_test.rb
@@ -1,0 +1,83 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AtlasEngine
+  module Pl
+    module AddressImporter
+      module Corrections
+        module OpenAddress
+          class EmptyStreetCorrectorTest < ActiveSupport::TestCase
+            setup do
+              @klass = EmptyStreetCorrector
+            end
+
+            test "#apply copies city name into street field when street is empty string" do
+              input_address = {
+                source_id: "OA#9ac45faa4a783dbf",
+                locale: "PL",
+                country_code: "PL",
+                province_code: "",
+                region1: "",
+                city: ["Kotowa Wola"],
+                suburb: nil,
+                zip: "37-415",
+                street: "",
+                building_and_unit_ranges: { "285" => {} },
+              }
+
+              expected = input_address.merge({ street: "Kotowa Wola" })
+
+              @klass.apply(input_address)
+
+              assert_equal expected, input_address
+            end
+
+            test "#apply does not copy a blank city name" do
+              input_address = {
+                source_id: "OA#9ac45faa4a783dbf",
+                locale: "PL",
+                country_code: "PL",
+                province_code: "",
+                region1: "",
+                city: [""],
+                suburb: nil,
+                zip: "37-415",
+                street: "",
+                building_and_unit_ranges: { "285" => {} },
+              }
+
+              expected = input_address.dup
+
+              @klass.apply(input_address)
+
+              assert_equal expected, input_address
+            end
+
+            test "#apply does not overwrite the street name when already present" do
+              input_address = {
+                source_id: "OA#9ac45faa4a783dbf",
+                locale: "PL",
+                country_code: "PL",
+                province_code: "",
+                region1: "",
+                city: ["Warszawa"],
+                suburb: nil,
+                zip: "03-938",
+                street: "Zwycięzców",
+                building_and_unit_ranges: { "40" => {} },
+              }
+
+              expected = input_address.dup
+
+              @klass.apply(input_address)
+
+              assert_equal expected, input_address
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/pl/address_importer/corrections/open_address/postal_code_placeholder_corrector_test.rb
+++ b/test/countries/atlas_engine/pl/address_importer/corrections/open_address/postal_code_placeholder_corrector_test.rb
@@ -1,0 +1,62 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AtlasEngine
+  module Pl
+    module AddressImporter
+      module Corrections
+        module OpenAddress
+          class PostalCodePlaceholderCorrectorTest < ActiveSupport::TestCase
+            setup do
+              @klass = PostalCodePlaceholderCorrector
+            end
+
+            test "#apply replaces 00-000 postal code with a nil" do
+              input_address = {
+                source_id: "OA#9ac45faa4a783dbf",
+                locale: "PL",
+                country_code: "PL",
+                province_code: "",
+                region1: "",
+                city: ["Kotowa Wola"],
+                suburb: nil,
+                zip: "00-000",
+                street: "",
+                building_and_unit_ranges: { "285" => {} },
+              }
+
+              expected = input_address.merge({ zip: nil })
+
+              @klass.apply(input_address)
+
+              assert_equal expected, input_address
+            end
+
+            test "#apply does not overwrite the zip otherwise" do
+              input_address = {
+                source_id: "OA#9ac45faa4a783dbf",
+                locale: "PL",
+                country_code: "PL",
+                province_code: "",
+                region1: "",
+                city: ["Warszawa"],
+                suburb: nil,
+                zip: "03-938",
+                street: "Zwycięzców",
+                building_and_unit_ranges: { "40" => {} },
+              }
+
+              expected = input_address.dup
+
+              @klass.apply(input_address)
+
+              assert_equal expected, input_address
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/pl/country_profile_test.rb
+++ b/test/countries/atlas_engine/pl/country_profile_test.rb
@@ -10,6 +10,15 @@ module AtlasEngine
         @profile = CountryProfile.for("PL")
       end
 
+      test "#correctors value is correct for source open-address" do
+        assert_equal [
+          Pl::AddressImporter::Corrections::OpenAddress::CityCorrector,
+          Pl::AddressImporter::Corrections::OpenAddress::PostalCodePlaceholderCorrector,
+          Pl::AddressImporter::Corrections::OpenAddress::EmptyStreetCorrector,
+        ],
+          @profile.ingestion.correctors(source: "open_address")
+      end
+
       test "#address_parser returns the custom PL parser" do
         assert_equal Pl::ValidationTranscriber::AddressParser,
           @profile.validation.address_parser


### PR DESCRIPTION
## Context
Part of #53 

## Approach
Add some correctors to edit the OpenAddresses data before indexing. Add a few common synonyms as well, although the list is likely not complete.

## Testing
 I can index all `pl/*` files on OpenAddresses.io without issue. Using some unreleased validation code (🤫) we can reach about 96% valid address accuracy on a rather small benchmarking suite.

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
