### PR TITLE
Allow address 2 to be nil in missing building num predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Allow nil address 2 in BuildingNumberInAddress1OrAddress2 predicate [#57](https://github.com/Shopify/atlas_engine/pull/57)
 - Improve indexing for Poland [#56](https://github.com/Shopify/atlas_engine/pull/56)
 - Configure sequence comparison policy for South Korea [#58](https://github.com/Shopify/atlas_engine/pull/58)
 - Configurable sequence comparison policy [#54](https://github.com/Shopify/atlas_engine/pull/54)

--- a/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2.rb
@@ -12,7 +12,7 @@ module AtlasEngine
               return unless @cache.country.country?
               return unless @cache.country.building_number_required
               return unless @cache.country.building_number_may_be_in_address2
-              return if contains_number?(T.must(@address.address1)) || contains_number?(T.must(@address.address2))
+              return if contains_number?(T.must(@address.address1)) || contains_number?(@address.address2)
 
               build_concern
             end
@@ -31,7 +31,7 @@ module AtlasEngine
               )
             end
 
-            sig { params(text: String).returns(T::Boolean) }
+            sig { params(text: T.nilable(String)).returns(T::Boolean) }
             def contains_number?(text)
               /[0-9\u0660-\u0669\u06f0-\u06f9\u0966-\u096f\uff10-\uff19]/.match?(text)
             end

--- a/test/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2_test.rb
@@ -57,6 +57,30 @@ module AtlasEngine
 
               assert_nil BuildingNumberInAddress1OrAddress2.new(field: :address1, address: address).evaluate
             end
+
+            test "when missing building number in address1 and address2 is nil" do
+              address = build_address_obj(
+                address1: "Marinierskade",
+                address2: nil,
+                city: "Amsterdam",
+                zip: "1018 HX",
+                country_code: "NL",
+              )
+
+              concern = BuildingNumberInAddress1OrAddress2.new(field: :address1, address: address).evaluate
+
+              expected_concern =
+                {
+                  field_names: [:address1, :address2, :country],
+                  message: "Add a building number if you have one.",
+                  code: :missing_building_number,
+                  type: "warning",
+                  type_level: 3,
+                  suggestion_ids: [],
+                }
+
+              assert_equal expected_concern, concern&.attributes
+            end
           end
         end
       end


### PR DESCRIPTION
## Context

Got this error when running benchmarking due to a `nil` address2 being passed into a `T.must()`:
```
Running suite "local" using file "/Users/gabypancu/Downloads/bq-results-20240124-161408-1706115549621 - bq-results-20240124-161408-1706115549621.csv"...
/Users/gabypancu/.gem/ruby/3.2.2/gems/sorbet-runtime-0.5.11214/lib/types/_types.rb:222:in `must': Passed `nil` into T.must (TypeError)

      raise TypeError.new("Passed `nil` into T.must")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from /Users/gabypancu/.gem/ruby/3.2.2/bundler/gems/atlas_engine-b2ba085aa7c4/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2.rb:15:in `evaluate'
```

## Approach

Removed the `T.must` and allowed nil params to the method.

## Testing

Benchmarking now runs successfully on my Italy file!

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
