### PR TITLE
add comparison policy for KR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
+
+- Configure sequence comparison policy for South Korea [#58](https://github.com/Shopify/atlas_engine/pull/58)
 - Configurable sequence comparison policy [#54](https://github.com/Shopify/atlas_engine/pull/54)
 - Emit StatsD validation metric when address_unknown concern is returned [#55](https://github.com/Shopify/atlas_engine/pull/55)
 - Enable ES level validation for Slovenia (SI) [#44](https://github.com/Shopify/atlas_engine/pull/44)

--- a/app/countries/atlas_engine/kr/country_profile.yml
+++ b/app/countries/atlas_engine/kr/country_profile.yml
@@ -5,6 +5,9 @@ ingestion:
 validation:
   enabled: true
   default_matching_strategy: es
+  comparison_policies:
+    city:
+      unmatched: ignore_left_unmatched
   restrictions:
     - class: AtlasEngine::Restrictions::UnsupportedScript
       params:


### PR DESCRIPTION
## Context

South Korean addresses require the city (시; si), following by the district (구; gu) [ref](https://www.grcdi.nl/gsb/south%20korea.html#HB8684CE730533E56377EC2A6514B9C27E54EDA7904BA2AA2ASouthA20KoreaA20A2DA20A5BA5BAddressesA7CAddressA20formatsA5DA5DA2AA2A00100400C01401701A01D02002C036040043046049). Clients will often put all of the city details (+ municipal subdivisions)) into the `city` field. 

Unfortunately, we do not have sufficient data to validate the district and other municipal subdivisions. Some of our address records have both the city and district details, but some only have city.
Result is that our suggestions would remove valuable municipal details. Example:
```
input: 부천시 소사구
input translation: Sosa-gu, Bucheon-si

suggestion: 부천시
suggestion translation: Bucheon-si
```

## Approach
Leveraging the new comparison policy feature, https://github.com/Shopify/atlas_engine/pull/54, configuring KR to ignore unmatched city tokens coming from the left (client input). This will ensure that in the above example, we are not suggesting a city WITHOUT important district details. 

## Testing
before
<img width="1003" alt="Screenshot 2024-01-24 at 3 42 45 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/a63c2970-9620-42e0-83b3-572613174ab5">
❌ suggestion on city, removing important city details 

after
<img width="959" alt="Screenshot 2024-01-24 at 3 42 15 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/64152ff0-42b1-44a2-8f5b-7a2fd11678e8">
✅ no suggestion or concerns on city 

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
