### PR TITLE
Add city comparison policy for CZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Add comparison policy for cities in CZ [#63](https://github.com/Shopify/atlas_engine/pull/63)
 - Allow Exclusions to apply on any address component and add an Exclusion for city validation in Italy [#61](https://github.com/Shopify/atlas_engine/pull/61)
 - Allow nil address 2 in BuildingNumberInAddress1OrAddress2 predicate [#57](https://github.com/Shopify/atlas_engine/pull/57)
 - Improve indexing for Poland [#56](https://github.com/Shopify/atlas_engine/pull/56)

--- a/app/countries/atlas_engine/cz/country_profile.yml
+++ b/app/countries/atlas_engine/cz/country_profile.yml
@@ -5,3 +5,6 @@ validation:
   address_parser: AtlasEngine::Cz::ValidationTranscriber::AddressParser
   query_builder: AtlasEngine::Cz::AddressValidation::Es::QueryBuilder
   has_provinces: false
+  comparison_policies:
+    city:
+      unmatched: ignore_left_unmatched


### PR DESCRIPTION
## Context

Part of https://github.com/Shopify/address/issues/2307
Resolves https://github.com/Shopify/address/issues/2450

In some major cities in CZ, a post office number or locality should be included after the city name ([source](https://youbianku.com/files/upu/CZE.pdf)). We don't always have this information in our DB. When users provide this info, we should not suggest removing it.

## Approach

Add a comparison policy for cities in CZ so that we allow extra tokens from the user and don't suggest removing them.


## Testing

🎩 
<img width="1317" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/8b8e8d51-6ba2-4557-8f8c-3a13c0483d7b">

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
