### PR TITLE
Add an `AddressComparison` argument to validation exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Add an AddressComparsion argument to validation exclusions [#64](https://github.com/Shopify/atlas_engine/pull/64)
 - Add comparison policy for cities in CZ [#63](https://github.com/Shopify/atlas_engine/pull/63)
 - Allow Exclusions to apply on any address component and add an Exclusion for city validation in Italy [#61](https://github.com/Shopify/atlas_engine/pull/61)
 - Allow nil address 2 in BuildingNumberInAddress1OrAddress2 predicate [#57](https://github.com/Shopify/atlas_engine/pull/57)

--- a/app/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city.rb
+++ b/app/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city.rb
@@ -14,10 +14,11 @@ module AtlasEngine
                   override.params(
                     session: AtlasEngine::AddressValidation::Session,
                     candidate: AtlasEngine::AddressValidation::Candidate,
+                    address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
                   )
                     .returns(T::Boolean)
                 end
-                def apply?(session, candidate)
+                def apply?(session, candidate, address_comparison)
                   true
                 end
               end

--- a/app/models/atlas_engine/address_validation/validators/full_address/candidate_result.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/candidate_result.rb
@@ -146,7 +146,7 @@ module AtlasEngine
 
           sig { returns(RelevantComponents) }
           def relevant_components
-            @relevant_components ||= RelevantComponents.new(session, candidate, street_comparison)
+            @relevant_components ||= RelevantComponents.new(session, candidate, address_comparison)
           end
 
           sig do

--- a/app/models/atlas_engine/address_validation/validators/full_address/exclusions/exclusion_base.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/exclusions/exclusion_base.rb
@@ -12,8 +12,14 @@ module AtlasEngine
               extend T::Helpers
               abstract!
 
-              sig { abstract.params(session: Session, candidate: Candidate).returns(T::Boolean) }
-              def apply?(session, candidate); end
+              sig do
+                abstract.params(
+                  session: Session,
+                  candidate: Candidate,
+                  address_comparison: AddressComparison,
+                ).returns(T::Boolean)
+              end
+              def apply?(session, candidate, address_comparison); end
             end
           end
         end

--- a/test/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city_test.rb
+++ b/test/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city_test.rb
@@ -21,7 +21,13 @@ module AtlasEngine
                   country_code: "IT",
                   zip: "38121",
                 )
-                assert City.apply?(session(address), candidate(address))
+                assert City.apply?(session(address), candidate(address), mock_address_comparison)
+              end
+
+              private
+
+              def mock_address_comparison
+                typed_mock(AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison)
               end
             end
           end


### PR DESCRIPTION
## Context
Part of #53 , follow up to #61 

Thanks to #61 countries may inspect either the address and/or candidate, then conditionally exclude an address field from the validation response accordingly. I would like to provide the address comparison to that list of arguments.  This way, we can implement more fine-grained exclusions. As an example, we could choose to validate italian cities as long as their comparison differs by a few letters.

## Approach
Mostly a plumbing PR, passing the address comparison from `CandidateResult` --> `RelevantComponents` --> `ExclusionsBase` --> exclusion implementations.

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
