### PR TITLE
Include unmatched token length in sequence comparison's "aggregate distance"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Include unmatched token length in sequence comparison's "aggregate distance" [#65](https://github.com/Shopify/atlas_engine/pull/65)
 - Add an AddressComparsion argument to validation exclusions [#64](https://github.com/Shopify/atlas_engine/pull/64)
 - Add comparison policy for cities in CZ [#63](https://github.com/Shopify/atlas_engine/pull/63)
 - Allow Exclusions to apply on any address component and add an Exclusion for city validation in Italy [#61](https://github.com/Shopify/atlas_engine/pull/61)

--- a/app/models/atlas_engine/address_validation/token/sequence/comparison.rb
+++ b/app/models/atlas_engine/address_validation/token/sequence/comparison.rb
@@ -45,7 +45,7 @@ module AtlasEngine
             longest_subsequence = longest_subsequence_comparison <=> other.longest_subsequence_comparison
             return -1 * longest_subsequence if longest_subsequence.nonzero?
 
-            edit_distance = aggregate_edit_distance <=> other.aggregate_edit_distance
+            edit_distance = aggregate_distance <=> other.aggregate_distance
             return edit_distance if edit_distance.nonzero?
 
             prefixes = count_by_qualifier(:prefix) <=> other.count_by_qualifier(:prefix)
@@ -92,7 +92,7 @@ module AtlasEngine
 
           sig { returns(T::Boolean) }
           def match?
-            aggregate_edit_distance == 0 && unmatched_tokens.empty?
+            aggregate_distance == 0 && unmatched_tokens.empty?
           end
 
           sig { params(threshold_percent: Float).returns(T::Boolean) }
@@ -101,8 +101,8 @@ module AtlasEngine
           end
 
           sig { returns(Integer) }
-          def aggregate_edit_distance
-            token_comparisons.sum(&:edit_distance)
+          def aggregate_distance
+            token_comparisons.sum(&:edit_distance) + unmatched_tokens.map(&:value).sum(&:length)
           end
 
           sig { returns(Integer) }

--- a/app/models/atlas_engine/address_validation/validators/full_address/suggestion_builder.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/suggestion_builder.rb
@@ -126,7 +126,7 @@ module AtlasEngine
               ).returns(String)
             end
             def generic_field_suggestion(comparison, candidate, field)
-              if comparison.token_match_count == 0 || comparison.aggregate_edit_distance > 2
+              if comparison.token_match_count == 0 || comparison.aggregate_distance > 2
                 candidate.component(field)&.first_value
               else
                 comparison.right_sequence.raw_value

--- a/test/models/atlas_engine/address_validation/token/sequence/comparison_test.rb
+++ b/test/models/atlas_engine/address_validation/token/sequence/comparison_test.rb
@@ -327,12 +327,14 @@ module AtlasEngine
             assert_not_predicate comparison, :potential_match?
           end
 
-          test "aggregate_edit_distance returns the sum of the edit distances in a comparison" do
+          test "aggregate_distance returns the sum of the edit distances in a comparison " \
+            "plus the combined length of all unmatched tokens" do
             comparisons = [@equal_0, @prefix_2]
 
-            seq_comp = sequence_comparison(token_comparisons: comparisons)
+            seq_comp = sequence_comparison(token_comparisons: comparisons, unmatched_tokens: [@dummy1])
 
-            assert_equal 2, seq_comp.aggregate_edit_distance
+            # "dummy1".length + edit distance of 2 from @prefix_2
+            assert_equal 8, seq_comp.aggregate_distance
           end
 
           test "token_match_count returns the total number of tokens matched" do


### PR DESCRIPTION
## Context
Part of #53

The `Token::Sequence::Comparison#aggregate_edit_distance` method is meant to capture the "string difference" between two sequences. A while back we stopped token pairs having less than 50% similarity as a match, and both tokens wound up in the `unmatched_tokens` array.

Because they no longer figured in the `token_comparisons` hash, their string diff no longer contributed to the `aggregate_edit_distance` value:
```ruby
sig { returns(Integer) }
def aggregate_distance
  token_comparisons.sum(&:edit_distance) # does not factor in unmatched tokens
end
```

So comparing "main street west" to "upper mian street" would produce
```
unmatched_tokens: [west, upper]
token_comparisons: [ { main COMP mian, edit_distance: 1 } ]
```
And the aggregate edit distance was 1, which ignores the length of "west" and "upper".

I would like to start using the aggregate edit distance of a sequence comparison, and I'd like the value to reflect all tokens on either side.

## Approach
Add the combined length of all unmatched tokens to the aggregate distance, and remove "edit" from the name since we're not strictly computing levenshtein distance anymore.

## Testing
I ran the dev_tagged suite before and after these changes, which made no difference:
```
+----------------------------------------------------------+---------+
| Field                                                    | Percent |
+----------------------------------------------------------+---------+
| % of confirmed validated addresses                       | 99.4%   |
| % of validated addresses that we INCORRECTLY flagged     | 0.6%    |
| % of known invalid addresses (with CORRECT suggestion)   | 79.8%   |
| % of known invalid addresses (with INCORRECT suggestion) | 7.1%    |
| % of known invalid addresses (with no suggestion)        | 13.1%   |
+----------------------------------------------------------+---------+
```
...

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
