### PR TITLE
Set unmatched component threshold in country profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Make unmatched_components_suggestion_threshold configurable in country profiles [#71](https://github.com/Shopify/atlas_engine/pull/71)
 - Include unmatched token length in sequence comparison's "aggregate distance" [#65](https://github.com/Shopify/atlas_engine/pull/65)
 - Add an AddressComparsion argument to validation exclusions [#64](https://github.com/Shopify/atlas_engine/pull/64)
 - Add comparison policy for cities in CZ [#63](https://github.com/Shopify/atlas_engine/pull/63)

--- a/app/countries/atlas_engine/it/country_profile.yml
+++ b/app/countries/atlas_engine/it/country_profile.yml
@@ -6,6 +6,7 @@ validation:
   exclusions:
     city:
       - AtlasEngine::It::AddressValidation::Validators::FullAddress::Exclusions::City
+  unmatched_components_suggestion_threshold: 1
 ingestion:
   open_address:
     feature_mapper: AtlasEngine::It::AddressImporter::OpenAddress::Mapper

--- a/app/models/atlas_engine/address_validation/validators/full_address/candidate_result.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/candidate_result.rb
@@ -61,7 +61,7 @@ module AtlasEngine
             concern = InvalidZipConcernBuilder.for(session.address, [])
             result.concerns << concern if concern
 
-            if ConcernBuilder.too_many_unmatched_components?(unmatched_components.keys)
+            if ConcernBuilder.too_many_unmatched_components?(session.address, unmatched_components.keys)
               result.concerns << UnknownAddressConcern.new(session.address)
             end
           end

--- a/app/models/atlas_engine/country_profile_validation_subset.rb
+++ b/app/models/atlas_engine/country_profile_validation_subset.rb
@@ -63,5 +63,10 @@ module AtlasEngine
         AddressValidation::Token::Sequence::ComparisonPolicy::DEFAULT_POLICY
       end
     end
+
+    sig { returns(Integer) }
+    def unmatched_components_suggestion_threshold
+      attributes.dig("validation", "unmatched_components_suggestion_threshold") || 2
+    end
   end
 end

--- a/db/data/country_profiles/default.yml
+++ b/db/data/country_profiles/default.yml
@@ -22,5 +22,6 @@ validation:
     city: {}
     zip: {}
     province_code: {}
+  unmatched_components_suggestion_threshold: 2
 decompounding_patterns:
   street: []

--- a/test/models/atlas_engine/address_validation/validators/full_address/concern_builder_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/concern_builder_test.rb
@@ -20,20 +20,20 @@ module AtlasEngine
               AddressValidation::Validators::FullAddress::UnknownZipForAddressConcern
             @unknown_province_klass =
               AddressValidation::Validators::FullAddress::UnknownProvinceConcern
-            @address = build_address
+            @address = build_address(country_code: "US")
             @suggestion_ids = []
           end
 
           test ".too_many_unmatched_components? is false when the # of unmatched components is below the threshold" do
-            assert_not @klass.too_many_unmatched_components?([:city])
+            assert_not @klass.too_many_unmatched_components?(@address, [:city])
           end
 
           test ".too_many_unmatched_components? is false when the # of unmatched components is at the threshold" do
-            assert_not @klass.too_many_unmatched_components?([:city, :province_code])
+            assert_not @klass.too_many_unmatched_components?(@address, [:city, :province_code])
           end
 
           test ".too_many_unmatched_components? is true when the # of unmatched components is above the threshold" do
-            assert @klass.too_many_unmatched_components?([:city, :province_code, :zip])
+            assert @klass.too_many_unmatched_components?(@address, [:city, :province_code, :zip])
           end
 
           test ".valid_zip_for_province? true when zip prefix is valid for province" do
@@ -167,7 +167,7 @@ module AtlasEngine
             address = build_address(country_code: "US", province_code: "CA", zip: "90210")
             unmatched_component_keys = [:province_code, :zip, :city]
 
-            assert unmatched_component_keys.size > @klass::UNMATCHED_COMPONENTS_SUGGESTION_THRESHOLD
+            assert unmatched_component_keys.size > 2
             assert_not @klass.should_suggest?(address, unmatched_component_keys)
           end
 

--- a/test/models/atlas_engine/default_profile_test.rb
+++ b/test/models/atlas_engine/default_profile_test.rb
@@ -32,5 +32,9 @@ module AtlasEngine
     test ".validation.normalized_components value is correct" do
       assert_equal [], @profile.validation.normalized_components
     end
+
+    test ".validation.unmatched_components_suggestion_threshold value is correct" do
+      assert_equal 2, @profile.validation.unmatched_components_suggestion_threshold
+    end
   end
 end


### PR DESCRIPTION
## Context

Part of https://github.com/Shopify/address/issues/2212

We still have some wrong zip suggestions in Italy due to finding the wrong candidate + not having the actual address in our DB:
<img width="1568" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/6402b7dd-e8d8-4081-80a0-a4a7dce7d0f2">

Notice how in most of these examples, the city is different and the zip is different. I'd like to update validation for Italy so that we don't provide a suggestion if the candidate differs from the input on more than one component (instead of two).

## Approach

Instead of hardcoding `UNMATCHED_COMPONENTS_SUGGESTION_THRESHOLD`, move it to country profile with a default value of 2.

## Testing

Benchmarking shows significantly fewer bad zip suggestions. We still get a few, but this gets rid of most of them.

Before:
<img width="1563" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/885e8fee-bf4a-4ce5-afeb-af9bbddd6dc0">


After:
<img width="1353" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/28205d9f-7194-468a-9cdc-1297def23ed4">

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
