### PR TITLE
Fix unmatched_components_suggestion_threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Fix lookup of unmatched_components_suggestion_threshold [#73](https://github.com/Shopify/atlas_engine/pull/73)
 - Add city corrector for Faroe Islands [#72](https://github.com/Shopify/atlas_engine/pull/72)
 - Configure validation support for Poland [#70](https://github.com/Shopify/atlas_engine/pull/70)
 - Make unmatched_components_suggestion_threshold configurable in country profiles [#71](https://github.com/Shopify/atlas_engine/pull/71)

--- a/app/models/atlas_engine/country_profile_validation_subset.rb
+++ b/app/models/atlas_engine/country_profile_validation_subset.rb
@@ -66,7 +66,7 @@ module AtlasEngine
 
     sig { returns(Integer) }
     def unmatched_components_suggestion_threshold
-      attributes.dig("validation", "unmatched_components_suggestion_threshold") || 2
+      attributes.dig("unmatched_components_suggestion_threshold") || 2
     end
   end
 end

--- a/test/countries/atlas_engine/it/country_profile_test.rb
+++ b/test/countries/atlas_engine/it/country_profile_test.rb
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AtlasEngine
+  module It
+    class CountryProfileTest < ActiveSupport::TestCase
+      setup do
+        @profile = CountryProfile.for("IT")
+      end
+
+      test "validation unmatched_components_suggestion_threshold is set to 1" do
+        assert_equal 1, @profile.validation.unmatched_components_suggestion_threshold
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The `unmatched_components_suggestion_threshold` method in the country profile validation subset was using the wrong nested attribute keys to grab the value.

## Approach

Remove `validation` from attribute keys when digging.

## Testing

Before (suggesting even though the candidate has a different zip and city and Italy's threshold is 1 unmatched component):
<img width="1278" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/2f19138c-4c68-4753-ad36-f771789ac236">

After:
<img width="1229" alt="image" src="https://github.com/Shopify/atlas_engine/assets/42747996/923f275b-c9a7-48f7-bcd7-5ae95931de6f">


## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
