### PR TITLE
Add kardynała synonym for poland

### DIFF
--- a/app/countries/atlas_engine/pl/synonyms.yml
+++ b/app/countries/atlas_engine/pl/synonyms.yml
@@ -5,6 +5,7 @@ street_synonyms:
 - plac, pl # square
 - ulica, ul # street
 ## titles
+- kardynała, kard # cardinal (masculine)
 - święta, św # saint (feminine)
 - świętego, św # saint
 - święty, św # saint (masculine)


### PR DESCRIPTION
## Context
Minor update to polish street synonyms. _kardynała_ (cardinal) appears in several street names and is sometimes shortened as _kard_.

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [ ] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
