### PR TITLE
Add parser and city exclusion for South Korea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Introduce parser and city exclusion for South Korea [#79](https://github.com/Shopify/atlas_engine/pull/79)
 - Prepare PT for es validation (address parser, synonyms, zip exclusion) [#46](https://github.com/Shopify/atlas_engine/pull/46)
 - Improve ingestion and validation for Slovenia [#76](https://github.com/Shopify/atlas_engine/pull/76)
 - Enable Sorbet/ForbidTStruct cop [#78] (https://github.com/Shopify/atlas_engine/pull/78)

--- a/app/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city.rb
+++ b/app/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city.rb
@@ -1,0 +1,69 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Kr
+    module AddressValidation
+      module Validators
+        module FullAddress
+          module Exclusions
+            class City <
+              AtlasEngine::AddressValidation::Validators::FullAddress::Exclusions::ExclusionBase
+              extend T::Sig
+              class << self
+                COMPONENT_IDENTIFIER = {
+                  si: "시",
+                  gu: "구",
+                }.freeze
+
+                sig do
+                  override.params(
+                    session: AtlasEngine::AddressValidation::Session,
+                    candidate: AtlasEngine::AddressValidation::Candidate,
+                    address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
+                  )
+                    .returns(T::Boolean)
+                end
+                def apply?(session, candidate, address_comparison)
+                  candidate_si = extract_component_from_city(candidate, :si)
+                  candidate_gu = extract_component_from_city(candidate, :gu)
+
+                  (candidate_si.present? && contains_component?(:si, candidate_si, session)) ||
+                    (candidate_gu.present? && contains_component?(:gu, candidate_gu, session))
+                end
+
+                private
+
+                sig do
+                  params(
+                    candidate: AtlasEngine::AddressValidation::Candidate,
+                    component: Symbol,
+                  ).returns(T.nilable(String))
+                end
+                def extract_component_from_city(candidate, component)
+                  city = candidate.component(:city)&.value&.first
+
+                  city_parts = city.split(" ")
+                  city_parts.find do |part|
+                    part.end_with?(COMPONENT_IDENTIFIER[component])
+                  end
+                end
+
+                sig do
+                  params(
+                    type: Symbol,
+                    value: String,
+                    session: AtlasEngine::AddressValidation::Session,
+                  ).returns(T::Boolean)
+                end
+                def contains_component?(type, value, session)
+                  session.parsings.parsings.pluck(type)&.include?(value) || session.city&.include?(value)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/countries/atlas_engine/kr/country_profile.yml
+++ b/app/countries/atlas_engine/kr/country_profile.yml
@@ -5,9 +5,13 @@ ingestion:
 validation:
   enabled: true
   default_matching_strategy: es
+  address_parser: AtlasEngine::Kr::ValidationTranscriber::AddressParser
   comparison_policies:
     city:
       unmatched: ignore_left_unmatched
+  exclusions:
+    city:
+      - AtlasEngine::Kr::AddressValidation::Validators::FullAddress::Exclusions::City
   restrictions:
     - class: AtlasEngine::Restrictions::UnsupportedScript
       params:

--- a/app/countries/atlas_engine/kr/validation_transcriber/address_parser.rb
+++ b/app/countries/atlas_engine/kr/validation_transcriber/address_parser.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Kr
+    module ValidationTranscriber
+      class AddressParser < AtlasEngine::ValidationTranscriber::AddressParserBase
+        private
+
+        PROVINCE = "(?<province>.+기|서울)"
+        GU = "(?<gu>.+구)"
+        SI = "(?<si>.+시)"
+        DONG = "(?<dong>.+동)"
+        EUP = "(?<eup>.+읍)"
+        STREET = "(?<street>\\S+)"
+        BUILDING_NUM = "(?<building_num>\\d+(^호)?)"
+        UNIT_NUM = "(?<unit_num>\\d+(^동)?)"
+
+        sig { returns(T::Array[Regexp]) }
+        def country_regex_formats
+          @country_regex_formats ||= [
+            %r{
+              (#{PROVINCE}\s+)?
+              (#{SI}\s+)?
+              (#{GU}\s+)?
+              (#{DONG}\s+)?
+              (#{EUP}\s+)?
+              (#{STREET}\s+)?
+              (#{BUILDING_NUM}(-|\s)?)?#{UNIT_NUM}?
+            }x,
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/lib/atlas_engine/validation_transcriber/address_parser_base.rb
+++ b/app/lib/atlas_engine/validation_transcriber/address_parser_base.rb
@@ -146,7 +146,7 @@ module AtlasEngine
         end
 
         street_tokens_ridiculous?(
-          street: T.must(street),
+          street: street,
           unit_type: unit_type,
           unit_num: unit_num,
           num_street_space: num_street_space,

--- a/test/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city_test.rb
+++ b/test/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city_test.rb
@@ -1,0 +1,151 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+require "models/atlas_engine/address_validation/address_validation_test_helper"
+
+module AtlasEngine
+  module Kr
+    module AddressValidation
+      module Validators
+        module FullAddress
+          module Exclusions
+            class CityTest < ActiveSupport::TestCase
+              include AtlasEngine::AddressValidation::AddressValidationTestHelper
+
+              test "#apply? returns true when candidate city (si only) is present in sesssion address components" do
+                address = build_address(
+                  address1: "창원시 마산회원구 양덕로190 7층 뷰티제이",
+                  city: "",
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                candidate_address = candidate(
+                  suburb: "석전동",
+                  street: "3·15대로",
+                  city: ["창원시"],
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                comparison = mock_address_comparison("창원시", "창원시")
+
+                assert City.apply?(session(address), candidate_address, comparison)
+              end
+
+              test "#apply? returns true when candidate city (gu only) is present in sesssion address components" do
+                address = build_address(
+                  address1: "마산회원구 양덕로190 7층 뷰티제이",
+                  city: "",
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                candidate_address = candidate(
+                  suburb: "석전동",
+                  street: "3·15대로",
+                  city: ["마산회원구"],
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                comparison = mock_address_comparison("창원시", "마산회원구")
+
+                assert City.apply?(session(address), candidate_address, comparison)
+              end
+
+              test "#apply? returns true when candidate city (si and gu) are present in session address components" do
+                address = build_address(
+                  address1: "마산회원구 양덕로190 7층 뷰티제이",
+                  city: "창원시",
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                candidate_address = candidate(
+                  suburb: "석전동",
+                  street: "3·15대로",
+                  city: ["창원시 마산회원구"],
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                comparison = mock_address_comparison("창원시", "창원시 마산회원구")
+
+                assert City.apply?(session(address), candidate_address, comparison)
+              end
+
+              test "#apply? returns false when candidate si is not present in session address components" do
+                address = build_address(
+                  address1: "양덕로190 7층 뷰티제이",
+                  city: "",
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                candidate_address = candidate(
+                  suburb: "석전동",
+                  street: "3·15대로",
+                  city: ["창원시"],
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                comparison = mock_address_comparison("창원시", "창원시 마산회원구")
+
+                assert_not City.apply?(session(address), candidate_address, comparison)
+              end
+
+              test "#apply? returns false when candidate gu is not present in session address components" do
+                address = build_address(
+                  address1: "양덕로190 7층 뷰티제이",
+                  city: "",
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                candidate_address = candidate(
+                  suburb: "석전동",
+                  street: "3·15대로",
+                  city: ["마산회원구"],
+                  country_code: "KR",
+                  zip: "51315",
+                  province_code: "KR-48",
+                )
+
+                comparison = mock_address_comparison("창원시", "창원시 마산회원구")
+
+                assert_not City.apply?(session(address), candidate_address, comparison)
+              end
+
+              def mock_address_comparison(given_city, candidate_city)
+                given_sequence = AtlasEngine::AddressValidation::Token::Sequence.from_string(given_city)
+                candidate_sequence = AtlasEngine::AddressValidation::Token::Sequence.from_string(candidate_city)
+                city_comparison = AtlasEngine::AddressValidation::Token::Sequence::Comparator.new(
+                  left_sequence: given_sequence,
+                  right_sequence: candidate_sequence,
+                ).compare
+
+                address_comparison = typed_mock(
+                  AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
+                )
+                address_comparison.stubs(:city_comparison).returns(city_comparison)
+                address_comparison
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/kr/validation_transcriber/address_parser_test.rb
+++ b/test/countries/atlas_engine/kr/validation_transcriber/address_parser_test.rb
@@ -1,0 +1,93 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AtlasEngine
+  module Kr
+    module ValidationTranscriber
+      class AddressParserTest < ActiveSupport::TestCase
+        include ValidationTranscriber
+
+        test "CountryProfile for KR loads the correct address parser" do
+          assert_equal(AddressParser, CountryProfile.for("KR").validation.address_parser)
+        end
+
+        test "Parses one line Korean addresses" do
+          [
+            # Gu, 구, followed by street
+            [:kr, "마산회원구 양덕로190 7층 뷰티제이", [{ gu: "마산회원구", street: "양덕로190", building_num: "7" }]],
+            # Province (Seoul), followed by gu 구, followed by street
+            [
+              :kr,
+              "서울 서대문구 연희동 129-1",
+              [{ province: "서울", gu: "서대문구", dong: "연희동", building_num: "129", unit_num: "1" }],
+            ],
+            # Si, 시, followed by street
+            [:kr, "김포시 양촌읍 황금로 117", [{ si: "김포시", eup: "양촌읍", street: "황금로", building_num: "117" }]],
+            # Si, 시, followed by street
+            [:kr, "하남시 미사강변남로 91 (망월동)", [{ si: "하남시", street: "미사강변남로", building_num: "91" }]],
+            # Si, 시, followed by gu, 구, followed by street
+            [
+              :kr,
+              "수원시 장안구 송정로46번길 18-14 (정자동)",
+              [{ si: "수원시", gu: "장안구", street: "송정로46번길", building_num: "18", unit_num: "14" }],
+            ],
+            # Province, followed by si, 시, followed by gu, 구, followed by street
+            [
+              :kr,
+              "경기 성남시 분당구 동판교로 122",
+              [{ province: "경기", si: "성남시", gu: "분당구", street: "동판교로", building_num: "122" }],
+            ],
+          ].each do |country_code, address1, expected|
+            check_parsing(country_code, address1, nil, expected)
+          end
+        end
+
+        test "Two line Korean addresses" do
+          [
+            [
+              :kr,
+              "기흥구 보라동 민속마을 신창아파트",
+              "201동801호",
+              [
+                { gu: "기흥구", dong: "보라동", street: "민속마을" },
+                { building_num: "201" },
+              ],
+            ],
+            [
+              :kr,
+              "경기 성남시 분당구 동판교로 122",
+              " (백현동, 백현마을2단지아파트)208동 503호 ",
+              [
+                { province: "경기", si: "성남시", gu: "분당구", street: "동판교로", building_num: "122" },
+                { dong: " (백현동, 백현마을2단지아파트)208동", street: "503호" },
+                { province: "경기", si: "성남시", gu: "분당구", dong: "동판교로 122  (백현동, 백현마을2단지아파트)208동", street: "503호" },
+              ],
+            ],
+          ].each do |country_code, address1, address2, expected|
+            check_parsing(country_code, address1, address2, expected)
+          end
+        end
+
+        private
+
+        def check_parsing(country_code, address1, address2, expected, components = nil)
+          components ||= {}
+          components.merge!(country_code: country_code.to_s.upcase, address1: address1, address2: address2)
+          address = AtlasEngine::AddressValidation::Address.new(**components)
+
+          actual = AddressParser.new(address: address).parse
+
+          assert(
+            expected.to_set.subset?(actual.to_set),
+            "For input ( address1: #{address1.inspect}, address2: #{address2.inspect} )\n\n " \
+              "#{expected.inspect} \n\n" \
+              "Must be included in: \n\n" \
+              "#{actual.inspect}",
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
Part of the work to support validation in South Korea 

Today, we see users inputting municipal address details in both the `city` field and the `address1/2` fields (screenshot). When the city details are NOT present in the **city** field, the validation logic will return `city_inconsistent` and suggest the required city. 
<img width="973" alt="Screenshot 2024-01-29 at 4 36 15 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/83a1cbc3-a83e-43a2-9f70-f17a0698b877">

In these cases, where the required municipal details are present in address1/address2, the validation should not return city concerns or suggestions. 

## Approach
Added an address parser to strip the different components of Korean addresses; more info on [Korean address formats here](https://www.grcdi.nl/gsb/south%20korea.html#HB8684CE730533E56377EC2A6514B9C27E54EDA7904BA2AA2ASouthA20KoreaA20A2DA20A5BA5BAddressesA7CAddressA20formatsA5DA5DA2AA2A00100400C01401701A01D02002C036040043046049).

Use the address parser to parse out any municipal details, notably the `si` and `gu`, which are the toplevel and district components for a municipality. OSM stores this data in `city`. 

Then, add an exclusion to ensure city concerns are not returned when the required data is present in any of address1, address2, or city fields. 

## Testing
From a set of 488 hangul addressees 

**Benchmarking before:**
<img width="587" alt="Screenshot 2024-01-29 at 4 59 54 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/b112615f-5982-490c-a79c-7c57d2ec3ab5">

- 116 city_inconsistent 
  - of 20 confirmed, 14 had the municipal data in address1 form field (70%) 
  - 4 were valid (20%) 
  - 2 were errors (10%) 

**Benchmarking after:**
<img width="596" alt="Screenshot 2024-01-29 at 4 59 46 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/a19a7c04-6c01-4f16-8010-b6020027d9d3">
- 8 city_inconsistent 🎉 

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
