### PR TITLE
Store a duplicate of Result in ConcernRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Improved validation suggestions for Luxembourg [#82](https://github.com/Shopify/atlas_engine/pull/82)
+- Store a duplicate of Result in ConcernRecord [#85](https://github.com/Shopify/atlas_engine/pull/85)
 - Introduce parser and city exclusion for South Korea [#79](https://github.com/Shopify/atlas_engine/pull/79)
 - Prepare PT for es validation (address parser, synonyms, zip exclusion) [#46](https://github.com/Shopify/atlas_engine/pull/46)
 - Improve ingestion and validation for Slovenia [#76](https://github.com/Shopify/atlas_engine/pull/76)

--- a/app/models/atlas_engine/address_validation/concern_record.rb
+++ b/app/models/atlas_engine/address_validation/concern_record.rb
@@ -53,12 +53,17 @@ module AtlasEngine
           new(
             **T.unsafe(
               {
-                result: result,
+                result: duplicate(result),
                 **result.address,
                 **context.except(:client_request_id),
               },
             ),
           )
+        end
+
+        sig { params(obj: T.untyped).returns(T.untyped) }
+        def duplicate(obj)
+          Marshal.load(Marshal.dump(obj))
         end
       end
 

--- a/test/graphql/atlas_engine/schema_test.rb
+++ b/test/graphql/atlas_engine/schema_test.rb
@@ -14,8 +14,8 @@ module AtlasEngine
       previous_definition = file_schema.read
 
       assert_equal(
-        current_definition,
         previous_definition,
+        current_definition,
         <<~MESSAGE.squish,
           The current schema is out of date.
           Update the schema with `rake app:atlas_engine:graphql:schema_dump`.


### PR DESCRIPTION
## Context
Storing the instance of a Result in a ConcernRecord allows for the possibility of further edits to this Result later on in the parent application, which essentially rewrites history for that concern record. The concern record's `result` should be immutable at the point where it is added to the concern queue.

## Approach
I tried to call `deep_dup` on the result object but parts of the result were still being changed by the parent app later on.  Because we're in a time crunch I have decided to serialize/deserialize the result object to ensure independence.  It's a bit heavy handed, but we're only doing it once per validation.

We can revisit later.

## Testing
Validated an address having a bad city name, then manually removed all `concern` objects from the result in the parent controller.  The recorded concern still showed the city_inconsistent concern, as expected.

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
