### PR TITLE
Country specific field comparison classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Country specific field comparison classes [#98](https://github.com/Shopify/atlas_engine/pull/98)
 - Update `AddressComparison.<field_comparison>` methods to return `FieldComparisonBase` instances instead of `Token::Sequence::Comparison` [#95](https://github.com/Shopify/atlas_engine/pull/95)
 - Address TestCase#fixture_path deprecation [#94](https://github.com/Shopify/atlas_engine/pull/94)
 - Address parser test cleanup [#92](https://github.com/Shopify/atlas_engine/pull/92)

--- a/app/models/atlas_engine/address_validation/validators/full_address/address_comparison.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/address_comparison.rb
@@ -42,35 +42,27 @@ module AtlasEngine
 
           sig { returns(ZipComparison) }
           def zip_comparison
-            @zip_comparison ||= ZipComparison.new(address: address, candidate: candidate, datastore: datastore)
+            @zip_comparison ||= field_comparison(field: :zip)
           end
 
           sig { returns(StreetComparison) }
           def street_comparison
-            @street_comparison ||= StreetComparison.new(address: address, candidate: candidate, datastore: datastore)
+            @street_comparison ||= field_comparison(field: :street)
           end
 
           sig { returns(CityComparison) }
           def city_comparison
-            @city_comparison ||= CityComparison.new(address: address, candidate: candidate, datastore: datastore)
+            @city_comparison ||= field_comparison(field: :city)
           end
 
           sig { returns(ProvinceCodeComparison) }
           def province_code_comparison
-            @province_code_comparison ||= ProvinceCodeComparison.new(
-              address: address,
-              candidate: candidate,
-              datastore: datastore,
-            )
+            @province_code_comparison ||= field_comparison(field: :province_code)
           end
 
           sig { returns(BuildingComparison) }
           def building_comparison
-            @building_comparison ||= BuildingComparison.new(
-              address: address,
-              candidate: candidate,
-              datastore: datastore,
-            )
+            @building_comparison ||= field_comparison(field: :building)
           end
 
           protected
@@ -101,6 +93,12 @@ module AtlasEngine
           sig { returns(AtlasEngine::AddressValidation::Token::Sequence::Comparison) }
           def merged_comparison
             @merged_comparisons ||= text_comparisons.reduce(&:merge)
+          end
+
+          sig { params(field: Symbol).returns(FieldComparisonBase) }
+          def field_comparison(field:)
+            klass = CountryProfile.for(address.country_code).validation.address_comparison(field: field)
+            klass.new(address: address, candidate: candidate, datastore: datastore)
           end
         end
       end

--- a/app/models/atlas_engine/address_validation/validators/full_address/field_comparison_base.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/field_comparison_base.rb
@@ -11,6 +11,8 @@ module AtlasEngine
 
           abstract!
 
+          SUPPORTED_FIELDS = Set.new([:street, :city, :zip, :province_code, :building])
+
           sig { params(address: AbstractAddress, candidate: Candidate, datastore: DatastoreBase).void }
           def initialize(address:, candidate:, datastore:)
             @address = address

--- a/app/models/atlas_engine/country_profile_validation_subset.rb
+++ b/app/models/atlas_engine/country_profile_validation_subset.rb
@@ -68,5 +68,14 @@ module AtlasEngine
     def unmatched_components_suggestion_threshold
       attributes.dig("unmatched_components_suggestion_threshold") || 2
     end
+
+    sig { params(field: Symbol).returns(T::Class[AddressValidation::Validators::FullAddress::FieldComparisonBase]) }
+    def address_comparison(field:)
+      unless field.in?(AddressValidation::Validators::FullAddress::FieldComparisonBase::SUPPORTED_FIELDS)
+        raise ArgumentError.new, "Field #{field} is not supported"
+      end
+
+      attributes.dig("address_comparison", field.to_s).constantize
+    end
   end
 end

--- a/db/data/country_profiles/default.yml
+++ b/db/data/country_profiles/default.yml
@@ -23,5 +23,11 @@ validation:
     zip: {}
     province_code: {}
   unmatched_components_suggestion_threshold: 2
+  address_comparison:
+    street: AtlasEngine::AddressValidation::Validators::FullAddress::StreetComparison
+    city: AtlasEngine::AddressValidation::Validators::FullAddress::CityComparison
+    zip: AtlasEngine::AddressValidation::Validators::FullAddress::ZipComparison
+    province_code: AtlasEngine::AddressValidation::Validators::FullAddress::ProvinceCodeComparison
+    building: AtlasEngine::AddressValidation::Validators::FullAddress::BuildingComparison
 decompounding_patterns:
   street: []

--- a/test/models/atlas_engine/country_profile_validation_subset_test.rb
+++ b/test/models/atlas_engine/country_profile_validation_subset_test.rb
@@ -78,5 +78,25 @@ module AtlasEngine
       assert_equal AddressValidation::Token::Sequence::ComparisonPolicy::DEFAULT_POLICY,
         validation_subset.comparison_policy(:street)
     end
+
+    test "address_comparison raises error if field is not supported" do
+      validation_subset = CountryProfile.for(CountryProfile::DEFAULT_PROFILE).validation
+      assert_raises(ArgumentError) { validation_subset.address_comparison(field: :unsupported_field) }
+    end
+
+    test "address_comparison returns the correct address comparison class for each field" do
+      validation_subset = CountryProfile.for(CountryProfile::DEFAULT_PROFILE).validation
+
+      assert_equal AddressValidation::Validators::FullAddress::StreetComparison,
+        validation_subset.address_comparison(field: :street)
+      assert_equal AddressValidation::Validators::FullAddress::CityComparison,
+        validation_subset.address_comparison(field: :city)
+      assert_equal AddressValidation::Validators::FullAddress::ZipComparison,
+        validation_subset.address_comparison(field: :zip)
+      assert_equal AddressValidation::Validators::FullAddress::ProvinceCodeComparison,
+        validation_subset.address_comparison(field: :province_code)
+      assert_equal AddressValidation::Validators::FullAddress::BuildingComparison,
+        validation_subset.address_comparison(field: :building)
+    end
   end
 end


### PR DESCRIPTION
## Context
[refer part 2 here](https://github.com/Shopify/atlas_engine/pull/95)

In part 3 we load the address field_comparison classes from CountryProfile. This will allow us to swap specific comparison logic by country

## Approach

Referenced the default field_comparison classes in `default.yml` and loaded using country profile in 'AddressComparison`

## Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->


## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
