### PR TITLE
Configurable zip prefix value in validation query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Add `zip_prefix_length` config in country profile to tune zip fuzzy search [#112](https://github.com/Shopify/atlas_engine/pull/112)
 - Add address parser and synonyms for Spain [#111](https://github.com/Shopify/atlas_engine/pull/111)
 - Update FR country profile to set has_provinces to false [#108](https://github.com/Shopify/atlas_engine/pull/108)
 - Add `.match?` method to `FieldComparisonBase` [#99](https://github.com/Shopify/atlas_engine/pull/99)

--- a/app/countries/atlas_engine/fr/country_profile.yml
+++ b/app/countries/atlas_engine/fr/country_profile.yml
@@ -12,3 +12,4 @@ validation:
   enabled: true
   default_matching_strategy: es
   has_provinces: false
+  zip_prefix_length: 3

--- a/app/models/atlas_engine/address_validation/es/query_builder.rb
+++ b/app/models/atlas_engine/address_validation/es/query_builder.rb
@@ -150,9 +150,14 @@ module AtlasEngine
           normalized_zip = ValidationTranscriber::ZipNormalizer.normalize(
             country_code: address.country_code, zip: address.zip,
           )
+
           {
             "match" => {
-              "zip" => { "query" => normalized_zip, "fuzziness" => "auto" },
+              "zip" => {
+                "query" => normalized_zip,
+                "fuzziness" => "auto",
+                "prefix_length" => profile.validation.zip_prefix_length,
+              },
             },
           }
         end

--- a/app/models/atlas_engine/country_profile_validation_subset.rb
+++ b/app/models/atlas_engine/country_profile_validation_subset.rb
@@ -77,5 +77,10 @@ module AtlasEngine
 
       attributes.dig("address_comparison", field.to_s).constantize
     end
+
+    sig { returns(Integer) }
+    def zip_prefix_length
+      attributes.dig("zip_prefix_length") || 0
+    end
   end
 end

--- a/test/fixtures/atlas_engine/address_validation/address_query_cz_no_street.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_cz_no_street.json
@@ -42,7 +42,7 @@
         },
         {
           "match": {
-            "zip": { "query": "683 04", "fuzziness": "auto" }
+            "zip": { "query": "683 04", "fuzziness": "auto", "prefix_length": 0 }
           }
         }
       ],

--- a/test/fixtures/atlas_engine/address_validation/address_query_cz_with_street.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_cz_with_street.json
@@ -66,7 +66,7 @@
         },
         {
           "match": {
-            "zip": { "query": "118 00", "fuzziness": "auto" }
+            "zip": { "query": "118 00", "fuzziness": "auto", "prefix_length": 0 }
           }
         }
       ],

--- a/test/fixtures/atlas_engine/address_validation/address_query_m28_1bq.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_m28_1bq.json
@@ -27,7 +27,7 @@
                   ]
                 }
               },
-              { "match": {"zip": {"query": "M28 1BQ", "fuzziness": "auto"}} }
+              { "match": {"zip": {"query": "M28 1BQ", "fuzziness": "auto", "prefix_length": 0 }} }
             ]
           }
         },
@@ -56,7 +56,7 @@
                   ]
                 }
               },
-              { "match": {"zip": {"query": "M28 1BQ", "fuzziness": "auto"}} }
+              { "match": {"zip": {"query": "M28 1BQ", "fuzziness": "auto", "prefix_length": 0 }} }
             ]
           }
         },
@@ -85,7 +85,7 @@
                   ]
                 }
               },
-              {"match": {"zip": {"query": "M28 1BQ", "fuzziness": "auto"}}}
+              {"match": {"zip": {"query": "M28 1BQ", "fuzziness": "auto", "prefix_length": 0 }}}
             ]
           }
         }

--- a/test/fixtures/atlas_engine/address_validation/address_query_mx.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_mx.json
@@ -33,7 +33,8 @@
           "match": {
             "zip": {
               "query": "24040",
-              "fuzziness": "auto"
+              "fuzziness": "auto",
+              "prefix_length": 0
             }
           }
         },

--- a/test/fixtures/atlas_engine/address_validation/address_query_nested_city_aliases_one_city_field.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_nested_city_aliases_one_city_field.json
@@ -43,7 +43,7 @@
         },
         {
           "match": {
-            "zip": { "query": "94102", "fuzziness": "auto" }
+            "zip": { "query": "94102", "fuzziness": "auto", "prefix_length": 0 }
           }
         },
         {

--- a/test/fixtures/atlas_engine/address_validation/address_query_pe30_5jr.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_pe30_5jr.json
@@ -26,7 +26,7 @@
                   ]
                 }
               },
-              { "match": { "zip": {"query": "PE30 5JR", "fuzziness": "auto"} } }
+              { "match": { "zip": {"query": "PE30 5JR", "fuzziness": "auto", "prefix_length": 0 } } }
             ]
           }
         },
@@ -54,7 +54,7 @@
                   ]
                 }
               },
-              { "match": {"zip": {"query": "PE30 5JR", "fuzziness": "auto"}} }
+              { "match": {"zip": {"query": "PE30 5JR", "fuzziness": "auto", "prefix_length": 0 }} }
             ]
           }
         }

--- a/test/fixtures/atlas_engine/address_validation/address_query_us.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us.json
@@ -43,7 +43,7 @@
         },
         {
           "match": {
-            "zip": { "query": "94102", "fuzziness": "auto" }
+            "zip": { "query": "94102", "fuzziness": "auto", "prefix_length": 0 }
           }
         },
         {

--- a/test/fixtures/atlas_engine/address_validation/address_query_us_a2.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us_a2.json
@@ -43,7 +43,7 @@
         },
         {
           "match": {
-            "zip": { "query": "94102", "fuzziness": "auto" }
+            "zip": { "query": "94102", "fuzziness": "auto", "prefix_length": 0 }
           }
         },
         {

--- a/test/fixtures/atlas_engine/address_validation/address_query_us_compound_street_name.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us_compound_street_name.json
@@ -62,7 +62,8 @@
           "match": {
             "zip": {
               "query": "77084",
-              "fuzziness": "auto"
+              "fuzziness": "auto",
+              "prefix_length": 0
             }
           }
         },

--- a/test/fixtures/atlas_engine/address_validation/address_query_us_missing.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_us_missing.json
@@ -25,7 +25,7 @@
         },
         {
           "match": {
-            "zip": { "query": "94102", "fuzziness": "auto" }
+            "zip": { "query": "94102", "fuzziness": "auto", "prefix_length": 0 }
           }
         },
         {

--- a/test/fixtures/atlas_engine/address_validation/address_query_with_fractional_building_number.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_with_fractional_building_number.json
@@ -70,7 +70,8 @@
           "match": {
             "zip": {
               "query": "94102",
-              "fuzziness": "auto"
+              "fuzziness": "auto",
+              "prefix_length": 0
             }
           }
         },

--- a/test/fixtures/atlas_engine/address_validation/address_query_without_building_number.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_without_building_number.json
@@ -41,7 +41,8 @@
           "match": {
             "zip": {
               "query": "94102",
-              "fuzziness": "auto"
+              "fuzziness": "auto",
+              "prefix_length": 0
             }
           }
         },

--- a/test/fixtures/atlas_engine/address_validation/address_query_without_province_code.json
+++ b/test/fixtures/atlas_engine/address_validation/address_query_without_province_code.json
@@ -49,7 +49,7 @@
         },
         {
           "match": {
-            "zip": { "query": "94102", "fuzziness": "auto" }
+            "zip": { "query": "94102", "fuzziness": "auto", "prefix_length": 0 }
           }
         }
       ],

--- a/test/models/atlas_engine/country_profile_validation_subset_test.rb
+++ b/test/models/atlas_engine/country_profile_validation_subset_test.rb
@@ -98,5 +98,23 @@ module AtlasEngine
       assert_equal AddressValidation::Validators::FullAddress::BuildingComparison,
         validation_subset.address_comparison(field: :building)
     end
+
+    test "zip_prefix_length returns the defined prefix length" do
+      profile_attributes = {
+        "validation" => {
+          "zip_prefix_length" => 3,
+        },
+      }
+
+      validation_subset = CountryProfile.new(profile_attributes).validation
+
+      assert_equal 3, validation_subset.zip_prefix_length
+    end
+
+    test "zip_prefix_length returns 0 if undefined" do
+      validation_subset = CountryProfile.for(CountryProfile::DEFAULT_PROFILE).validation
+
+      assert_equal 0, validation_subset.zip_prefix_length
+    end
   end
 end


### PR DESCRIPTION
## Context

This is an attempt to optimize our ES query results + execution time. By default, ES fuzzy query allows for edits anywhere in the query string. Because of the nature of zip values, even a single edit to the original query could explode to many matching documents, which may be impacting performance. 

This change is to allow for an optional configuration in the query builder to require the first x characters of the zip to match in the query since zips with a different value in their first few characters are very unlikely to be a match for a given query (ex zip of 90210 vs 02109 in the US are only an edit distance of 1 character but are located on opposite sides of the country and may as well not match at all.)

## Approach

Add a simple flag to the country profile to specify the prefix length. 

TODO:
Instead of manually specifying zip length in the country profile we could instead use worldwide to automatically derive the values. However, we may need to add another mechanism in the country profile if we want to conditionally disable this feature.

## Testing

At parity with US / FR benchmarking when configured with zip values.  

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
