### PR TITLE
[POC] Nz suburb comparison

### DIFF
--- a/app/countries/atlas_engine/nz/address_comparison/suburb_comparison.rb
+++ b/app/countries/atlas_engine/nz/address_comparison/suburb_comparison.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Nz
+    module AddressComparison
+      class SuburbComparison < AtlasEngine::AddressValidation::Validators::FullAddress::FieldComparisonBase
+        extend T::Sig
+
+        sig { override.returns(T.nilable(AtlasEngine::AddressValidation::Token::Sequence::Comparison)) }
+        def sequence_comparison
+          return @suburb_comparison if defined?(@suburb_comparison)
+
+          suburb_sequences = datastore.parsings.parsings.pluck(:suburb).uniq.compact.map do |suburb|
+            AtlasEngine::AddressValidation::Token::Sequence.from_string(suburb)
+          end
+
+          candidate_sequences = T.must(candidate.component(:suburb)).sequences
+
+          @suburb_comparison = suburb_sequences.map do |street_sequence|
+            best_comparison(
+              street_sequence,
+              candidate_sequences,
+              field_policy(:suburb),
+            )
+          end.min
+        end
+      end
+    end
+  end
+end

--- a/app/countries/atlas_engine/nz/country_profile.yml
+++ b/app/countries/atlas_engine/nz/country_profile.yml
@@ -2,6 +2,4 @@ id: NZ
 validation:
   address_parser: AtlasEngine::Nz::ValidationTranscriber::AddressParser
   address_comparison:
-    suburb:
-      comparator: AtlasEngine::Nz::AddressComparison::SuburbComparison
-      text_based: true
+    suburb: AtlasEngine::Nz::AddressComparison::SuburbComparison

--- a/app/countries/atlas_engine/nz/country_profile.yml
+++ b/app/countries/atlas_engine/nz/country_profile.yml
@@ -1,3 +1,3 @@
 id: NZ
 validation:
-  address_parser: AtlasEngine::ValidationTranscriber::AddressParserOceanic
+  address_parser: AtlasEngine::Nz::ValidationTranscriber::AddressParser

--- a/app/countries/atlas_engine/nz/country_profile.yml
+++ b/app/countries/atlas_engine/nz/country_profile.yml
@@ -1,3 +1,7 @@
 id: NZ
 validation:
   address_parser: AtlasEngine::Nz::ValidationTranscriber::AddressParser
+  address_comparison:
+    suburb:
+      comparator: AtlasEngine::Nz::AddressComparison::SuburbComparison
+      text_based: true

--- a/app/countries/atlas_engine/nz/validation_transcriber/address_parser.rb
+++ b/app/countries/atlas_engine/nz/validation_transcriber/address_parser.rb
@@ -1,0 +1,33 @@
+# typed: strict
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Nz
+    module ValidationTranscriber
+      class AddressParser < AtlasEngine::ValidationTranscriber::AddressParserBase
+        extend T::Sig
+
+        sig { override.returns(T::Array[AddressComponents]) }
+        def parse
+          address_components = super
+
+          # TEMPORARY: hacky extraction of suburb for POC
+          address_components.map do |parsing|
+            parsing[:suburb] = T.must(@address.address2) if @address.address2.present?
+          end
+
+          address_components
+        end
+
+        private
+
+        sig { returns(T::Array[Regexp]) }
+        def country_regex_formats
+          @country_regex_formats ||= [
+            %r{^((?<unit_num>[[:alpha:]0-9]+)/)?(?<building_num>[0-9][[:alpha:]0-9]*)\s+(?<street>.+)$},
+          ]
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/nz/validation_transcriber/address_parser_test.rb
+++ b/test/countries/atlas_engine/nz/validation_transcriber/address_parser_test.rb
@@ -10,10 +10,14 @@ module AtlasEngine
       class AddressParserTest < ActiveSupport::TestCase
         include AtlasEngine::AddressValidation::AddressValidationTestHelper
 
-        test "One line addresses" do
+        test "Parser can extract suburb from address2" do
           [
-            # building number incorrectly added before street name, with punctuation
-            [:nz, "1028 RIVER ROAD", "QUEENWOOD", [{ street: "RIVER ROAD", building_num: "1028", suburb: "QUEENWOOD" }]],
+            [
+              :nz,
+              "1028 RIVER ROAD",
+              "QUEENWOOD",
+              [{ street: "RIVER ROAD", building_num: "1028", suburb: "QUEENWOOD" }],
+            ],
           ].each do |country_code, address1, address2, expected|
             check_parsing(AddressParser, country_code, address1, address2, expected)
           end

--- a/test/countries/atlas_engine/nz/validation_transcriber/address_parser_test.rb
+++ b/test/countries/atlas_engine/nz/validation_transcriber/address_parser_test.rb
@@ -1,0 +1,24 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+require "models/atlas_engine/address_validation/address_validation_test_helper"
+
+module AtlasEngine
+  module Nz
+    module ValidationTranscriber
+      class AddressParserTest < ActiveSupport::TestCase
+        include AtlasEngine::AddressValidation::AddressValidationTestHelper
+
+        test "One line addresses" do
+          [
+            # building number incorrectly added before street name, with punctuation
+            [:nz, "1028 RIVER ROAD", "QUEENWOOD", [{ street: "RIVER ROAD", building_num: "1028", suburb: "QUEENWOOD" }]],
+          ].each do |country_code, address1, address2, expected|
+            check_parsing(AddressParser, country_code, address1, address2, expected)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Depends on : https://github.com/Shopify/atlas_engine/pull/122

For NZ we need to use the `address2` field to query the `suburb` value in ES and also compare suburb in our validation logic

This POC attempts to hack a simple working for this.
...

## Approach

1. Make AddressComparison dynamic (Hence now we can define a different set of components to use for comparison based on country)
2. Added an AddressParser for NZ to extract `suburb` from the `address2`
3. Add a `SuburbComparison` logic to compare suburb from ES results as well

## Testing

```
			address1: "8 Tauhara Drive"
			address2: "Queenwood"
			city: "Hamilton"
			zip: "3210" 
			provinceCode: "WKO"
			countryCode: NZ
```

above address now uses Queenwood too for the comparison. Hence if city, zip were both wrong we can still find the right candidate

![screenshot](https://screenshot.click/13-38-ae0qi-9fjhu.png)

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [ ] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
