### PR TITLE
Dynamic address component comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove session from Validation::Exclusion [#135](https://github.com/Shopify/atlas_engine/pull/135)
 - Send parsings and country profile into QueryBuilder initializer [#134](https://github.com/Shopify/atlas_engine/pull/134)
 - Remove the unnecessary instantiation of worldwide region from CountryProfile.for [#130](https://github.com/Shopify/atlas_engine/pull/130)
+- Dynamically load adress comparison components [#122](https://github.com/Shopify/atlas_engine/pull/122)
 
 ---
 

--- a/app/models/atlas_engine/address_validation/validators/full_address/building_comparison.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/building_comparison.rb
@@ -8,6 +8,11 @@ module AtlasEngine
         class BuildingComparison < FieldComparisonBase
           extend T::Sig
 
+          sig { override.returns(T::Boolean) }
+          def relevant?
+            false
+          end
+
           sig { override.returns(T.nilable(NumberComparison)) }
           def sequence_comparison
             @building_comparison ||= NumberComparison.new(

--- a/app/models/atlas_engine/address_validation/validators/full_address/candidate_result.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/candidate_result.rb
@@ -9,8 +9,6 @@ module AtlasEngine
           extend T::Sig
           include LogHelper
 
-          delegate :street_comparison, to: :address_comparison
-
           sig do
             params(
               candidate: AddressValidation::CandidateTuple,
@@ -127,8 +125,8 @@ module AtlasEngine
           def matched_and_unmatched_components
             components = {}
             @matched_and_unmatched_components ||= begin
-              components_to_compare.each do |field|
-                components[field] = @address_comparison.send(:"#{field}_comparison").sequence_comparison
+              components_to_compare.each do |component|
+                components[component] = @address_comparison.for(component).sequence_comparison
               end
               components
             end

--- a/app/models/atlas_engine/address_validation/validators/full_address/city_comparison.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/city_comparison.rb
@@ -8,6 +8,11 @@ module AtlasEngine
         class CityComparison < FieldComparisonBase
           extend T::Sig
 
+          sig { override.returns(T::Boolean) }
+          def relevant?
+            true
+          end
+
           sig { override.returns(T.nilable(Token::Sequence::Comparison)) }
           def sequence_comparison
             return @city_comparison if defined?(@city_comparison)

--- a/app/models/atlas_engine/address_validation/validators/full_address/field_comparison_base.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/field_comparison_base.rb
@@ -11,14 +11,26 @@ module AtlasEngine
 
           abstract!
 
-          SUPPORTED_FIELDS = Set.new([:street, :city, :zip, :province_code, :building])
+          sig { returns(Symbol) }
+          attr_reader :component
 
-          sig { params(address: AbstractAddress, candidate: Candidate, datastore: DatastoreBase).void }
-          def initialize(address:, candidate:, datastore:)
+          sig do
+            params(
+              address: AbstractAddress,
+              candidate: Candidate,
+              datastore: DatastoreBase,
+              component: Symbol,
+            ).void
+          end
+          def initialize(address:, candidate:, datastore:, component:)
             @address = address
             @datastore = datastore
             @candidate = candidate
+            @component = component
           end
+
+          sig { abstract.returns(T::Boolean) }
+          def relevant?; end
 
           sig { abstract.returns(T.any(T.nilable(Token::Sequence::Comparison), T.nilable(NumberComparison))) }
           def sequence_comparison; end

--- a/app/models/atlas_engine/address_validation/validators/full_address/province_code_comparison.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/province_code_comparison.rb
@@ -8,6 +8,11 @@ module AtlasEngine
         class ProvinceCodeComparison < FieldComparisonBase
           extend T::Sig
 
+          sig { override.returns(T::Boolean) }
+          def relevant?
+            true
+          end
+
           sig { override.returns(T.nilable(Token::Sequence::Comparison)) }
           def sequence_comparison
             return @province_code_comparison if defined?(@province_code_comparison)

--- a/app/models/atlas_engine/address_validation/validators/full_address/relevant_components.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/relevant_components.rb
@@ -17,13 +17,6 @@ module AtlasEngine
           sig { returns(AddressComparison) }
           attr_reader :address_comparison
 
-          ALL_SUPPORTED_COMPONENTS = [
-            :province_code,
-            :city,
-            :zip,
-            :street,
-          ].freeze
-
           sig do
             params(
               session: Session,
@@ -35,11 +28,12 @@ module AtlasEngine
             @session = session
             @candidate = candidate
             @address_comparison = address_comparison
+            @all_supported_components = address_comparison.relevant_components.dup
           end
 
           sig { returns(T::Array[Symbol]) }
           def components_to_validate
-            supported_components = ALL_SUPPORTED_COMPONENTS.dup - unsupported_components_for_country
+            supported_components = @all_supported_components.dup - unsupported_components_for_country
             apply_exclusions(supported_components)
             supported_components.delete(:street) if exclude_street_validation?
             supported_components
@@ -47,7 +41,7 @@ module AtlasEngine
 
           sig { returns(T::Array[Symbol]) }
           def components_to_compare
-            ALL_SUPPORTED_COMPONENTS.dup - unsupported_components_for_country
+            @all_supported_components.dup - unsupported_components_for_country
           end
 
           private

--- a/app/models/atlas_engine/address_validation/validators/full_address/street_comparison.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/street_comparison.rb
@@ -8,6 +8,11 @@ module AtlasEngine
         class StreetComparison < FieldComparisonBase
           extend T::Sig
 
+          sig { override.returns(T::Boolean) }
+          def relevant?
+            true
+          end
+
           sig { override.returns(T.nilable(Token::Sequence::Comparison)) }
           def sequence_comparison
             return @street_comparison if defined?(@street_comparison)

--- a/app/models/atlas_engine/address_validation/validators/full_address/zip_comparison.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/zip_comparison.rb
@@ -8,6 +8,11 @@ module AtlasEngine
         class ZipComparison < FieldComparisonBase
           extend T::Sig
 
+          sig { override.returns(T::Boolean) }
+          def relevant?
+            true
+          end
+
           sig { override.returns(T.nilable(Token::Sequence::Comparison)) }
           def sequence_comparison
             return @zip_comparison if defined?(@zip_comparison)

--- a/app/models/atlas_engine/country_profile_validation_subset.rb
+++ b/app/models/atlas_engine/country_profile_validation_subset.rb
@@ -69,13 +69,9 @@ module AtlasEngine
       attributes.dig("unmatched_components_suggestion_threshold") || 2
     end
 
-    sig { params(field: Symbol).returns(T::Class[AddressValidation::Validators::FullAddress::FieldComparisonBase]) }
-    def address_comparison(field:)
-      unless field.in?(AddressValidation::Validators::FullAddress::FieldComparisonBase::SUPPORTED_FIELDS)
-        raise ArgumentError.new, "Field #{field} is not supported"
-      end
-
-      attributes.dig("address_comparison", field.to_s).constantize
+    sig { params(component: Symbol).returns(T::Class[AddressValidation::Validators::FullAddress::FieldComparisonBase]) }
+    def component_comparison(component)
+      attributes.dig("address_comparison", component.to_s).constantize
     end
 
     sig { returns(Integer) }

--- a/test/models/atlas_engine/address_validation/validators/full_address/address_comparison_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/address_comparison_test.rb
@@ -282,6 +282,28 @@ module AtlasEngine
             )
             assert_not address_comparison.potential_match?
           end
+
+          test "#components returns the components from the country profile" do
+            assert_equal(
+              [:street, :city, :zip, :province_code, :building],
+              AddressComparison.new(
+                address: @address,
+                candidate: @candidate,
+                datastore: @datastore,
+              ).components,
+            )
+          end
+
+          test "#relevant_components returns only relevant components from the country profile when requested" do
+            assert_equal(
+              [:street, :city, :zip, :province_code],
+              AddressComparison.new(
+                address: @address,
+                candidate: @candidate,
+                datastore: @datastore,
+              ).relevant_components,
+            )
+          end
         end
       end
     end

--- a/test/models/atlas_engine/address_validation/validators/full_address/building_comparison_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/building_comparison_test.rb
@@ -21,7 +21,7 @@ module AtlasEngine
             address = build_address(country_code: "CA", address1: "1 Main St")
             datastore = Es::Datastore.new(address: address)
 
-            building_comparison = BuildingComparison.new(address:, candidate:, datastore:)
+            building_comparison = BuildingComparison.new(address:, candidate:, datastore:, component: :building)
 
             comparison = building_comparison.sequence_comparison
 

--- a/test/models/atlas_engine/address_validation/validators/full_address/city_comparison_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/city_comparison_test.rb
@@ -21,7 +21,7 @@ module AtlasEngine
             input_city_sequence = Token::Sequence.from_string(address.city)
             datastore.city_sequence = input_city_sequence
 
-            city_comparison = CityComparison.new(address:, candidate:, datastore:)
+            city_comparison = CityComparison.new(address:, candidate:, datastore:, component: :city)
 
             comparison = city_comparison.sequence_comparison
             candidate_city_sequences = candidate.component(:city).sequences
@@ -49,7 +49,7 @@ module AtlasEngine
             input_city_sequence = Token::Sequence.from_string(address.city)
             datastore.city_sequence = input_city_sequence
 
-            city_comparison = CityComparison.new(address:, candidate:, datastore:)
+            city_comparison = CityComparison.new(address:, candidate:, datastore:, component: :city)
 
             comparison = city_comparison.sequence_comparison
             candidate_city_sequences = candidate.component(:city).sequences

--- a/test/models/atlas_engine/address_validation/validators/full_address/field_comparison_base_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/field_comparison_base_test.rb
@@ -14,6 +14,11 @@ module AtlasEngine
           include AddressValidationTestHelper
 
           class DummyFieldComparison < FieldComparisonBase
+            sig { override.returns(T::Boolean) }
+            def relevant?
+              true
+            end
+
             def sequence_comparison
               nil
             end
@@ -27,6 +32,7 @@ module AtlasEngine
               address: @address,
               candidate: @candidate,
               datastore: @datastore,
+              component: :zip,
             )
           end
 

--- a/test/models/atlas_engine/address_validation/validators/full_address/province_code_comparison_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/province_code_comparison_test.rb
@@ -21,7 +21,12 @@ module AtlasEngine
             address = build_address(province_code: "US-TX", country_code: "US")
             datastore = Es::Datastore.new(address: address)
 
-            province_code_comparison = ProvinceCodeComparison.new(address:, candidate:, datastore:)
+            province_code_comparison = ProvinceCodeComparison.new(
+              address:,
+              candidate:,
+              datastore:,
+              component: :province_code,
+            )
 
             comparison = province_code_comparison.sequence_comparison
 
@@ -40,7 +45,12 @@ module AtlasEngine
             address = build_address(province_code: "US-PR", country_code: "US")
             datastore = Es::Datastore.new(address: address)
 
-            province_code_comparison = ProvinceCodeComparison.new(address:, candidate:, datastore:)
+            province_code_comparison = ProvinceCodeComparison.new(
+              address:,
+              candidate:,
+              datastore:,
+              component: :province_code,
+            )
 
             comparison = province_code_comparison.sequence_comparison
 

--- a/test/models/atlas_engine/address_validation/validators/full_address/relevant_components_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/relevant_components_test.rb
@@ -26,8 +26,13 @@ module AtlasEngine
             @address = create_address
             @session = session(@address, AddressValidation::MatchingStrategies::EsStreet)
             @candidate = candidate(@address)
+            @all_components = [
+              :province_code,
+              :city,
+              :zip,
+              :street,
+            ]
             @address_comparison = mock_address_comparison
-            @all_components = RelevantComponents::ALL_SUPPORTED_COMPONENTS
           end
 
           test "#components_to_compare returns an array of all supported components" do
@@ -189,6 +194,7 @@ module AtlasEngine
 
             typed_mock(AddressComparison).tap do |mock|
               mock.stubs(:street_comparison).returns(street_comparison_mock)
+              mock.stubs(:relevant_components).returns(@all_components)
             end
           end
 

--- a/test/models/atlas_engine/address_validation/validators/full_address/street_comparison_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/street_comparison_test.rb
@@ -20,7 +20,7 @@ module AtlasEngine
             input_street_sequences = [Token::Sequence.from_string(address.address1)]
             datastore.street_sequences = input_street_sequences
 
-            street_comparison = StreetComparison.new(address:, candidate:, datastore:)
+            street_comparison = StreetComparison.new(address:, candidate:, datastore:, component: :street)
 
             comparison = street_comparison.sequence_comparison
             candidate_street_sequences = candidate.component(:street).sequences

--- a/test/models/atlas_engine/address_validation/validators/full_address/zip_comparison_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/zip_comparison_test.rb
@@ -18,7 +18,7 @@ module AtlasEngine
             address = build_address(country_code: "CA", zip: "j9a2v2")
             datastore = Es::Datastore.new(address: address)
 
-            zip_comparison = ZipComparison.new(address:, candidate:, datastore:)
+            zip_comparison = ZipComparison.new(address:, candidate:, datastore:, component: :zip)
 
             comparison = zip_comparison.sequence_comparison
             candidate_zip_sequences = candidate.component(:zip).sequences
@@ -34,7 +34,7 @@ module AtlasEngine
             address = build_address(country_code: "AR", zip: "S2919")
             datastore = Es::Datastore.new(address: address)
 
-            zip_comparison = ZipComparison.new(address:, candidate:, datastore:)
+            zip_comparison = ZipComparison.new(address:, candidate:, datastore:, component: :zip)
 
             comparison = zip_comparison.sequence_comparison
 
@@ -52,7 +52,7 @@ module AtlasEngine
             address = build_address(country_code: "CA", zip: "j9a2v2")
             datastore = Es::Datastore.new(address: address)
 
-            zip_comparison = ZipComparison.new(address:, candidate:, datastore:)
+            zip_comparison = ZipComparison.new(address:, candidate:, datastore:, component: :zip)
 
             comparison = zip_comparison.sequence_comparison
             candidate_zip_sequences = candidate.component(:zip).sequences

--- a/test/models/atlas_engine/country_profile_validation_subset_test.rb
+++ b/test/models/atlas_engine/country_profile_validation_subset_test.rb
@@ -79,24 +79,19 @@ module AtlasEngine
         validation_subset.comparison_policy(:street)
     end
 
-    test "address_comparison raises error if field is not supported" do
-      validation_subset = CountryProfile.for(CountryProfile::DEFAULT_PROFILE).validation
-      assert_raises(ArgumentError) { validation_subset.address_comparison(field: :unsupported_field) }
-    end
-
-    test "address_comparison returns the correct address comparison class for each field" do
+    test "component_comparison returns the correct address comparison class for each field" do
       validation_subset = CountryProfile.for(CountryProfile::DEFAULT_PROFILE).validation
 
       assert_equal AddressValidation::Validators::FullAddress::StreetComparison,
-        validation_subset.address_comparison(field: :street)
+        validation_subset.component_comparison(:street)
       assert_equal AddressValidation::Validators::FullAddress::CityComparison,
-        validation_subset.address_comparison(field: :city)
+        validation_subset.component_comparison(:city)
       assert_equal AddressValidation::Validators::FullAddress::ZipComparison,
-        validation_subset.address_comparison(field: :zip)
+        validation_subset.component_comparison(:zip)
       assert_equal AddressValidation::Validators::FullAddress::ProvinceCodeComparison,
-        validation_subset.address_comparison(field: :province_code)
+        validation_subset.component_comparison(:province_code)
       assert_equal AddressValidation::Validators::FullAddress::BuildingComparison,
-        validation_subset.address_comparison(field: :building)
+        validation_subset.component_comparison(:building)
     end
 
     test "zip_prefix_length returns the defined prefix length" do


### PR DESCRIPTION
## Context

Part 1: Dynamic Address Comparison

We found that NZ addresses typically have the suburb mentioned in address2. This extra information is an important part of the address and can help us find the right candidate more accurately.

We currently do not use address2 to query a specific field in ES. Consequently after querying we also need to compare address2 and the candidate found in ES.

At the moment our address comparison logic is hardcoded to only compare `street`, `city`, `zip`, `building` and `province_code`.

This PR makes the address comparison logic dynamic so that we can configure a country to allow for more fields (components) to be compared if required.


## Approach

1. Moved the comparator loading logic in `AddressComparison` to load from CountryProfile
2. Updated references to use the dynamic list of comparators instead of a hardcoded one.

## Testing

Local validation for a few countries (NZ, LU) work as expected

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
