### PR TITLE
Remove unnecessary instantiation of worldwide region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-nil.
+- Remove the unnecessary instantiation of worldwide region from CountryProfile.for [#130](https://github.com/Shopify/atlas_engine/pull/130)
 
 ---
 

--- a/app/models/atlas_engine/country_profile.rb
+++ b/app/models/atlas_engine/country_profile.rb
@@ -71,6 +71,11 @@ module AtlasEngine
 
     DEFAULT_PROFILE = "DEFAULT"
 
+    COUNTRIES = T.let(
+      Worldwide::Regions.all.select(&:country?).reject(&:deprecated?).map(&:iso_code).to_set,
+      T::Set[String],
+    )
+
     add_index :id, unique: true
     self.base_path = ""
     self.backend = Backend
@@ -183,7 +188,7 @@ module AtlasEngine
       def for(country_code, locale = nil)
         raise CountryNotFoundError if country_code.blank?
 
-        unless country_code == DEFAULT_PROFILE || Worldwide.region(code: country_code).country?
+        unless country_code == DEFAULT_PROFILE || COUNTRIES.include?(country_code.upcase)
           raise CountryNotFoundError
         end
 


### PR DESCRIPTION
## Context
Removes the unnecessary instantiation of worldwide region from CountryProfile.for 

## Approach
^

## Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
