### PR TITLE
remove session dependency from validation exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Remove session from Validation::Exclusion [#135](https://github.com/Shopify/atlas_engine/pull/135)
 - Send parsings and country profile into QueryBuilder initializer [#134](https://github.com/Shopify/atlas_engine/pull/134)
 - Remove the unnecessary instantiation of worldwide region from CountryProfile.for [#130](https://github.com/Shopify/atlas_engine/pull/130)
 

--- a/app/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city.rb
+++ b/app/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city.rb
@@ -12,13 +12,12 @@ module AtlasEngine
               class << self
                 sig do
                   override.params(
-                    session: AtlasEngine::AddressValidation::Session,
                     candidate: AtlasEngine::AddressValidation::Candidate,
                     address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
                   )
                     .returns(T::Boolean)
                 end
-                def apply?(session, candidate, address_comparison)
+                def apply?(candidate, address_comparison)
                   true
                 end
               end

--- a/app/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city.rb
+++ b/app/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city.rb
@@ -18,18 +18,17 @@ module AtlasEngine
 
                 sig do
                   override.params(
-                    session: AtlasEngine::AddressValidation::Session,
                     candidate: AtlasEngine::AddressValidation::Candidate,
                     address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
                   )
                     .returns(T::Boolean)
                 end
-                def apply?(session, candidate, address_comparison)
+                def apply?(candidate, address_comparison)
                   candidate_si = extract_component_from_city(candidate, :si)
                   candidate_gu = extract_component_from_city(candidate, :gu)
 
-                  (candidate_si.present? && contains_component?(:si, candidate_si, session)) ||
-                    (candidate_gu.present? && contains_component?(:gu, candidate_gu, session))
+                  (candidate_si.present? && contains_component?(:si, candidate_si, address_comparison)) ||
+                    (candidate_gu.present? && contains_component?(:gu, candidate_gu, address_comparison))
                 end
 
                 private
@@ -53,11 +52,12 @@ module AtlasEngine
                   params(
                     type: Symbol,
                     value: String,
-                    session: AtlasEngine::AddressValidation::Session,
+                    address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
                   ).returns(T::Boolean)
                 end
-                def contains_component?(type, value, session)
-                  session.parsings.parsings.pluck(type)&.include?(value) || session.city&.include?(value)
+                def contains_component?(type, value, address_comparison)
+                  address_comparison.parsings.parsings.pluck(type)&.include?(value) ||
+                    address_comparison.address.city&.include?(value)
                 end
               end
             end

--- a/app/countries/atlas_engine/pl/address_validation/exclusions/placeholder_postal_code.rb
+++ b/app/countries/atlas_engine/pl/address_validation/exclusions/placeholder_postal_code.rb
@@ -11,12 +11,11 @@ module AtlasEngine
           class << self
             sig do
               override.params(
-                session: AtlasEngine::AddressValidation::Session,
                 candidate: AtlasEngine::AddressValidation::Candidate,
                 address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
               ).returns(T::Boolean)
             end
-            def apply?(session, candidate, address_comparison)
+            def apply?(candidate, address_comparison)
               placeholder_postal_code?(candidate)
             end
 

--- a/app/countries/atlas_engine/pl/address_validation/exclusions/rural_address.rb
+++ b/app/countries/atlas_engine/pl/address_validation/exclusions/rural_address.rb
@@ -11,12 +11,11 @@ module AtlasEngine
           class << self
             sig do
               override.params(
-                session: AtlasEngine::AddressValidation::Session,
                 candidate: AtlasEngine::AddressValidation::Candidate,
                 address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
               ).returns(T::Boolean)
             end
-            def apply?(session, candidate, address_comparison)
+            def apply?(candidate, address_comparison)
               rural_address?(candidate) && poor_city_match?(address_comparison)
             end
 

--- a/app/countries/atlas_engine/pt/address_validation/validators/full_address/exclusions/zip.rb
+++ b/app/countries/atlas_engine/pt/address_validation/validators/full_address/exclusions/zip.rb
@@ -11,13 +11,12 @@ module AtlasEngine
               class << self
                 sig do
                   override.params(
-                    session: AtlasEngine::AddressValidation::Session,
                     candidate: AtlasEngine::AddressValidation::Candidate,
                     address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
                   )
                     .returns(T::Boolean)
                 end
-                def apply?(session, candidate, address_comparison)
+                def apply?(candidate, address_comparison)
                   street_comparison_result = address_comparison.street_comparison.sequence_comparison
                   building_comparison_result = address_comparison.building_comparison.sequence_comparison
 

--- a/app/countries/atlas_engine/si/address_validation/exclusions/unknown_city.rb
+++ b/app/countries/atlas_engine/si/address_validation/exclusions/unknown_city.rb
@@ -11,12 +11,11 @@ module AtlasEngine
           class << self
             sig do
               override.params(
-                session: AtlasEngine::AddressValidation::Session,
                 candidate: AtlasEngine::AddressValidation::Candidate,
                 address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
               ).returns(T::Boolean)
             end
-            def apply?(session, candidate, address_comparison)
+            def apply?(candidate, address_comparison)
               poor_city_match?(address_comparison)
             end
 

--- a/app/models/atlas_engine/address_validation/validators/full_address/address_comparison.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/address_comparison.rb
@@ -11,6 +11,8 @@ module AtlasEngine
 
           attr_reader :address, :candidate, :datastore
 
+          delegate :parsings, to: :datastore
+
           sig { params(address: AbstractAddress, candidate: Candidate, datastore: DatastoreBase).void }
           def initialize(address:, candidate:, datastore:)
             @address = address

--- a/app/models/atlas_engine/address_validation/validators/full_address/exclusions/exclusion_base.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/exclusions/exclusion_base.rb
@@ -14,12 +14,11 @@ module AtlasEngine
 
               sig do
                 abstract.params(
-                  session: Session,
                   candidate: Candidate,
                   address_comparison: AddressComparison,
                 ).returns(T::Boolean)
               end
-              def apply?(session, candidate, address_comparison); end
+              def apply?(candidate, address_comparison); end
             end
           end
         end

--- a/app/models/atlas_engine/address_validation/validators/full_address/relevant_components.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/relevant_components.rb
@@ -56,7 +56,7 @@ module AtlasEngine
           def apply_exclusions(supported_components)
             supported_components.delete_if do |component|
               exclusions(component).any? do |exclusion|
-                if exclusion.apply?(session, candidate, address_comparison)
+                if exclusion.apply?(candidate, address_comparison)
                   emit_excluded_validation(component, "excluded")
                   true
                 end

--- a/test/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city_test.rb
+++ b/test/countries/atlas_engine/it/address_validation/validators/full_address/exclusions/city_test.rb
@@ -21,7 +21,7 @@ module AtlasEngine
                   country_code: "IT",
                   zip: "38121",
                 )
-                assert City.apply?(session(address), candidate(address), mock_address_comparison)
+                assert City.apply?(candidate(address), mock_address_comparison)
               end
 
               private

--- a/test/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city_test.rb
+++ b/test/countries/atlas_engine/kr/address_validation/validators/full_address/exclusions/city_test.rb
@@ -31,9 +31,9 @@ module AtlasEngine
                   province_code: "KR-48",
                 )
 
-                comparison = mock_address_comparison("창원시", "창원시")
+                comparison = mock_address_comparison(address, "창원시", "창원시")
 
-                assert City.apply?(session(address), candidate_address, comparison)
+                assert City.apply?(candidate_address, comparison)
               end
 
               test "#apply? returns true when candidate city (gu only) is present in sesssion address components" do
@@ -54,9 +54,9 @@ module AtlasEngine
                   province_code: "KR-48",
                 )
 
-                comparison = mock_address_comparison("창원시", "마산회원구")
+                comparison = mock_address_comparison(address, "창원시", "마산회원구")
 
-                assert City.apply?(session(address), candidate_address, comparison)
+                assert City.apply?(candidate_address, comparison)
               end
 
               test "#apply? returns true when candidate city (si and gu) are present in session address components" do
@@ -77,9 +77,9 @@ module AtlasEngine
                   province_code: "KR-48",
                 )
 
-                comparison = mock_address_comparison("창원시", "창원시 마산회원구")
+                comparison = mock_address_comparison(address, "창원시", "창원시 마산회원구")
 
-                assert City.apply?(session(address), candidate_address, comparison)
+                assert City.apply?(candidate_address, comparison)
               end
 
               test "#apply? returns false when candidate si is not present in session address components" do
@@ -100,9 +100,9 @@ module AtlasEngine
                   province_code: "KR-48",
                 )
 
-                comparison = mock_address_comparison("창원시", "창원시 마산회원구")
+                comparison = mock_address_comparison(address, "창원시", "창원시 마산회원구")
 
-                assert_not City.apply?(session(address), candidate_address, comparison)
+                assert_not City.apply?(candidate_address, comparison)
               end
 
               test "#apply? returns false when candidate gu is not present in session address components" do
@@ -123,12 +123,12 @@ module AtlasEngine
                   province_code: "KR-48",
                 )
 
-                comparison = mock_address_comparison("창원시", "창원시 마산회원구")
+                comparison = mock_address_comparison(address, "창원시", "창원시 마산회원구")
 
-                assert_not City.apply?(session(address), candidate_address, comparison)
+                assert_not City.apply?(candidate_address, comparison)
               end
 
-              def mock_address_comparison(given_city, candidate_city)
+              def mock_address_comparison(session_address, given_city, candidate_city)
                 given_sequence = AtlasEngine::AddressValidation::Token::Sequence.from_string(given_city)
                 candidate_sequence = AtlasEngine::AddressValidation::Token::Sequence.from_string(candidate_city)
                 city_comparison = AtlasEngine::AddressValidation::Token::Sequence::Comparator.new(
@@ -140,6 +140,10 @@ module AtlasEngine
                   AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
                 )
                 address_comparison.stubs(:city_comparison).returns(city_comparison)
+
+                parsings = parsings_for(session_address)
+                address_comparison.stubs(:parsings).returns(parsings)
+                address_comparison.stubs(:address).returns(session_address)
                 address_comparison
               end
             end

--- a/test/countries/atlas_engine/pl/address_validation/exclusions/placeholder_postal_code_test.rb
+++ b/test/countries/atlas_engine/pl/address_validation/exclusions/placeholder_postal_code_test.rb
@@ -12,13 +12,6 @@ module AtlasEngine
           include AtlasEngine::AddressValidation::AddressValidationTestHelper
 
           test "#apply? returns true when candidate has placeholder zip" do
-            address = build_address(
-              address1: "Artyleryjska 18c",
-              city: "Bolesławiec",
-              country_code: "PL",
-              zip: "59-700",
-            )
-
             candidate_address = build_address(
               address1: "Artyleryjska",
               city: "Bolesławiec",
@@ -26,7 +19,7 @@ module AtlasEngine
               zip: "00-000",
             )
             candidate = candidate(candidate_address)
-            assert PlaceholderPostalCode.apply?(session(address), candidate, mock_address_comparison)
+            assert PlaceholderPostalCode.apply?(candidate, mock_address_comparison)
           end
 
           test "#apply? returns false otherwise" do
@@ -37,7 +30,7 @@ module AtlasEngine
               zip: "59-700",
             )
             candidate = candidate(address)
-            assert_not PlaceholderPostalCode.apply?(session(address), candidate, mock_address_comparison)
+            assert_not PlaceholderPostalCode.apply?(candidate, mock_address_comparison)
           end
 
           private

--- a/test/countries/atlas_engine/pl/address_validation/exclusions/rural_address_test.rb
+++ b/test/countries/atlas_engine/pl/address_validation/exclusions/rural_address_test.rb
@@ -14,13 +14,6 @@ module AtlasEngine
           include AtlasEngine::AddressValidation::TokenHelper
 
           test "#apply? returns true when candidate has matching street and city names and city comparison is poor" do
-            address = build_address(
-              address1: "Kotowa Wola 285",
-              city: "Zaleszany",
-              country_code: "PL",
-              zip: "37-415",
-            )
-
             rural_candidate_address = build_address(
               address1: "Kotowa Wola",
               city: "Kotowa Wola",
@@ -29,17 +22,10 @@ module AtlasEngine
             )
             candidate = candidate(rural_candidate_address)
             comparison = mock_address_comparison("Zaleszany", "Kotowa Wola")
-            assert RuralAddress.apply?(session(address), candidate, comparison)
+            assert RuralAddress.apply?(candidate, comparison)
           end
 
           test "#apply? returns false when candidate has matching street and city names and city comparison is close" do
-            address = build_address(
-              address1: "Kotowa Wola 285",
-              city: "Kotowa Kola", # only one letter off
-              country_code: "PL",
-              zip: "37-415",
-            )
-
             rural_candidate_address = build_address(
               address1: "Kotowa Wola",
               city: "Kotowa Wola",
@@ -48,17 +34,10 @@ module AtlasEngine
             )
             candidate = candidate(rural_candidate_address)
             comparison = mock_address_comparison("Kotowa Kola", "Kotowa Wola")
-            assert_not RuralAddress.apply?(session(address), candidate, comparison)
+            assert_not RuralAddress.apply?(candidate, comparison)
           end
 
           test "#apply? returns false when candidate has differing street and city values (not rural)" do
-            address = build_address(
-              address1: "Kotowa Wola 285",
-              city: "Zaleszany",
-              country_code: "PL",
-              zip: "37-415",
-            )
-
             candidate_address = build_address(
               address1: "Kotowa Wola",
               city: "Trzebnica",
@@ -67,7 +46,7 @@ module AtlasEngine
             )
             candidate = candidate(candidate_address)
             comparison = mock_address_comparison("Zaleszany", "Trzebnica")
-            assert_not RuralAddress.apply?(session(address), candidate, comparison)
+            assert_not RuralAddress.apply?(candidate, comparison)
           end
 
           private

--- a/test/countries/atlas_engine/pt/address_validation/validators/full_address/exclusions/zip_test.rb
+++ b/test/countries/atlas_engine/pt/address_validation/validators/full_address/exclusions/zip_test.rb
@@ -29,7 +29,7 @@ module AtlasEngine
                   address1: "Rua Marginal",
                   building_and_unit_ranges: "{\"(0..99)/1\": {}}",
                 })
-                assert Zip.apply?(session(@address), @candidate, address_comparison)
+                assert Zip.apply?(@candidate, address_comparison)
               end
 
               test "#apply? returns true if building number does not match" do
@@ -37,7 +37,7 @@ module AtlasEngine
                   address1: "Avenida Marginal",
                   building_and_unit_ranges: "{\"(100..299)/1\": {}}",
                 })
-                assert Zip.apply?(session(@address), @candidate, address_comparison)
+                assert Zip.apply?(@candidate, address_comparison)
               end
 
               test "#apply? returns false only if building and street comparison match exactly" do
@@ -45,7 +45,7 @@ module AtlasEngine
                   address1: "Avenida Marginal",
                   building_and_unit_ranges: "{\"(0..99)/1\": {}}",
                 })
-                assert_not Zip.apply?(session(@address), @candidate, address_comparison)
+                assert_not Zip.apply?(@candidate, address_comparison)
               end
 
               private

--- a/test/countries/atlas_engine/si/address_validation/exclusions/unknown_city_test.rb
+++ b/test/countries/atlas_engine/si/address_validation/exclusions/unknown_city_test.rb
@@ -14,13 +14,6 @@ module AtlasEngine
           include AtlasEngine::AddressValidation::TokenHelper
 
           test "#apply? returns true when city comparison is poor" do
-            address = build_address(
-              address1: "Belca 40",
-              city: "Mojstrana",
-              country_code: "SI",
-              zip: "4281",
-            )
-
             rural_candidate_address = build_address(
               address1: "Belca",
               city: "Belca",
@@ -29,17 +22,10 @@ module AtlasEngine
             )
             candidate = candidate(rural_candidate_address)
             comparison = mock_address_comparison("Mojstrana", "Belca")
-            assert UnknownCity.apply?(session(address), candidate, comparison)
+            assert UnknownCity.apply?(candidate, comparison)
           end
 
           test "#apply? returns false when city comparison is close" do
-            address = build_address(
-              address1: "Moste 63i",
-              city: "Komends", # only one letter off
-              country_code: "SI",
-              zip: "1218",
-            )
-
             rural_candidate_address = build_address(
               address1: "Moste",
               city: "Komenda",
@@ -48,7 +34,7 @@ module AtlasEngine
             )
             candidate = candidate(rural_candidate_address)
             comparison = mock_address_comparison("Komends", "Komenda")
-            assert_not UnknownCity.apply?(session(address), candidate, comparison)
+            assert_not UnknownCity.apply?(candidate, comparison)
           end
 
           private

--- a/test/models/atlas_engine/address_validation/validators/full_address/relevant_components_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/relevant_components_test.rb
@@ -16,7 +16,7 @@ module AtlasEngine
 
           class DummyExclusion
             class << self
-              def apply?(_session, _candidate, mock_address_comparison)
+              def apply?(_candidate, mock_address_comparison)
                 true
               end
             end


### PR DESCRIPTION
## Context
A single validation exclusion depends on the session object. The session is used to load the address parsings. This is not necessary, as the parsings are actually available through the address comparison object. 

Removing the dependency on session brings us one step closer to eliminating the session god object. 

**This is a breaking change**, as it removes a param from the exclusion initializer. 

## Approach
`delegate :parsings, to: :datastore` from AddressComparison 

Updates the city exclusion to pull parsings from the address comparison. 

Removes session from the validation exclusions.


## Testing
Ran benchmarking `dev_tagged` suite; no change as a resulted of this PR 

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
