### PR TITLE
Rearrange storage of mappers in country profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Rearrange storage of feature mappers in country profiles [#137](https://github.com/Shopify/atlas_engine/pull/137)
 - Remove session from Validation::Exclusion [#135](https://github.com/Shopify/atlas_engine/pull/135)
 - Send parsings and country profile into QueryBuilder initializer [#134](https://github.com/Shopify/atlas_engine/pull/134)
 - Remove the unnecessary instantiation of worldwide region from CountryProfile.for [#130](https://github.com/Shopify/atlas_engine/pull/130)

--- a/app/countries/atlas_engine/au/country_profile.yml
+++ b/app/countries/atlas_engine/au/country_profile.yml
@@ -3,8 +3,8 @@ ingestion:
   settings:
     min_zip_edge_ngram: "1"
     max_zip_edge_ngram: "4"
-  open_address:
-    feature_mapper: AtlasEngine::Au::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::Au::AddressImporter::OpenAddress::Mapper
 validation:
   address_parser: AtlasEngine::Au::ValidationTranscriber::AddressParser
   enabled: true

--- a/app/countries/atlas_engine/bm/country_profile.yml
+++ b/app/countries/atlas_engine/bm/country_profile.yml
@@ -3,8 +3,8 @@ ingestion:
   correctors:
     open_address:
       - AtlasEngine::Bm::AddressImporter::Corrections::OpenAddress::CityAliasCorrector
-  open_address:
-    feature_mapper: AtlasEngine::Bm::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::Bm::AddressImporter::OpenAddress::Mapper
 validation:
   enabled: true
   has_provinces: true

--- a/app/countries/atlas_engine/ch/country_profile.yml
+++ b/app/countries/atlas_engine/ch/country_profile.yml
@@ -9,8 +9,8 @@ validation:
     - fr
     - it
 ingestion:
-  open_address:
-    feature_mapper: AtlasEngine::Ch::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::Ch::AddressImporter::OpenAddress::Mapper
   correctors:
     open_address:
       - AtlasEngine::Ch::AddressImporter::Corrections::OpenAddress::LocaleCorrector

--- a/app/countries/atlas_engine/es/country_profile.yml
+++ b/app/countries/atlas_engine/es/country_profile.yml
@@ -1,3 +1,4 @@
 id: ES
 validation:
   address_parser: AtlasEngine::Es::ValidationTranscriber::AddressParser
+

--- a/app/countries/atlas_engine/it/country_profile.yml
+++ b/app/countries/atlas_engine/it/country_profile.yml
@@ -8,8 +8,8 @@ validation:
       - AtlasEngine::It::AddressValidation::Validators::FullAddress::Exclusions::City
   unmatched_components_suggestion_threshold: 1
 ingestion:
-  open_address:
-    feature_mapper: AtlasEngine::It::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::It::AddressImporter::OpenAddress::Mapper
   correctors:
     open_address:
       - AtlasEngine::It::AddressImporter::Corrections::OpenAddress::CityCorrector

--- a/app/countries/atlas_engine/kr/country_profile.yml
+++ b/app/countries/atlas_engine/kr/country_profile.yml
@@ -1,7 +1,7 @@
 id: KR
 ingestion:
-  open_address:
-    feature_mapper: AtlasEngine::Kr::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::Kr::AddressImporter::OpenAddress::Mapper
 validation:
   enabled: true
   default_matching_strategy: es

--- a/app/countries/atlas_engine/pt/country_profile.yml
+++ b/app/countries/atlas_engine/pt/country_profile.yml
@@ -3,8 +3,8 @@ ingestion:
   correctors:
     open_address:
       - AtlasEngine::Pt::AddressImporter::Corrections::OpenAddress::CityCorrector
-  open_address:
-    feature_mapper: AtlasEngine::Pt::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::Pt::AddressImporter::OpenAddress::Mapper
 validation:
   enabled: true
   default_matching_strategy: es

--- a/app/countries/atlas_engine/si/country_profile.yml
+++ b/app/countries/atlas_engine/si/country_profile.yml
@@ -1,7 +1,7 @@
 id: SI
 ingestion:
-  open_address:
-    feature_mapper: AtlasEngine::Si::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::Si::AddressImporter::OpenAddress::Mapper
   correctors:
     open_address:
       - AtlasEngine::Si::AddressImporter::OpenAddress::Corrections::CityDistrictCorrector

--- a/app/countries/atlas_engine/tt/country_profile.yml
+++ b/app/countries/atlas_engine/tt/country_profile.yml
@@ -1,7 +1,7 @@
 id: TT
 ingestion:
-  open_address:
-    feature_mapper: AtlasEngine::Tt::AddressImporter::OpenAddress::Mapper
+  post_address_mapper:
+    open_address: AtlasEngine::Tt::AddressImporter::OpenAddress::Mapper
 validation:
   address_parser: AtlasEngine::ValidationTranscriber::AddressParserNorthAmerica
   has_provinces: false

--- a/app/lib/atlas_engine/validation_transcriber/address_parser_base.rb
+++ b/app/lib/atlas_engine/validation_transcriber/address_parser_base.rb
@@ -23,15 +23,15 @@ module AtlasEngine
 
       BUILDING_NAME = "(?<building_name>[\\w ]+)"
       BUILDING_NUM =
-        "(?<building_num>("\
-          '([[:digit:]]+\s)?([[:digit:]]+/[[:digit:]]+)|'\
-          '[[:digit:]][[:alpha:][:digit:]/\-]*|'\
-          '[[:alpha:]][[:digit:]][[:alpha:][:digit:]/\-]*'\
+        "(?<building_num>(" \
+          '([[:digit:]]+\s)?([[:digit:]]+/[[:digit:]]+)|' \
+          '[[:digit:]][[:alpha:][:digit:]/\-]*|' \
+          '[[:alpha:]][[:digit:]][[:alpha:][:digit:]/\-]*' \
           "))"
       NUMERIC_ONLY_BUILDING_NUM =
-        "(?<building_num>("\
-          '([[:digit:]]+\s+)?[[:digit:]][[:digit:]/]*[[:digit:]]|'\
-          "[[:digit:]]+"\
+        "(?<building_num>(" \
+          '([[:digit:]]+\s+)?[[:digit:]][[:digit:]/]*[[:digit:]]|' \
+          "[[:digit:]]+" \
           "))"
       NON_NUMERIC_STREET = "(?<street>[^[:digit:]/ -].*)"
       STREET = "(?<street>.+)"

--- a/app/models/atlas_engine/address_importer/open_address/transformer.rb
+++ b/app/models/atlas_engine/address_importer/open_address/transformer.rb
@@ -11,7 +11,7 @@ module AtlasEngine
         def initialize(country_import:, locale: nil)
           @country_code = country_import.country_code
           @locale = locale
-          @mapper = CountryProfile.for(@country_code).ingestion.open_address_feature_mapper.new(
+          @mapper = CountryProfile.for(@country_code).ingestion.post_address_mapper("open_address").new(
             country_code: @country_code, locale: @locale,
           )
           @corrector = AddressImporter::Corrections::Corrector.new(country_code: @country_code, source: "open_address")

--- a/app/models/atlas_engine/country_profile_ingestion_subset.rb
+++ b/app/models/atlas_engine/country_profile_ingestion_subset.rb
@@ -24,9 +24,9 @@ module AtlasEngine
       attributes.dig("settings", "min_zip_edge_ngram")
     end
 
-    sig { returns(T::Class[AddressImporter::OpenAddress::DefaultMapper]) }
-    def open_address_feature_mapper
-      attributes.dig("open_address", "feature_mapper").constantize
+    sig { params(source: String).returns(T::Class[AddressImporter::OpenAddress::DefaultMapper]) }
+    def post_address_mapper(source)
+      attributes.dig("post_address_mapper", source).constantize
     end
 
     sig { returns(T.nilable(String)) }

--- a/app/models/atlas_engine/elasticsearch/repository.rb
+++ b/app/models/atlas_engine/elasticsearch/repository.rb
@@ -230,7 +230,7 @@ module AtlasEngine
         ).void
       end
       def update_aliases_for_index(index_name:, remove_alias:, add_alias:)
-        is_writable = add_alias == active_alias ? true : false
+        is_writable = add_alias == active_alias
 
         body = {
           actions: [

--- a/app/tasks/maintenance/atlas_engine/geo_json_import_task.rb
+++ b/app/tasks/maintenance/atlas_engine/geo_json_import_task.rb
@@ -18,12 +18,14 @@ module Maintenance
       attribute :geojson_file_path, :string
       attribute :locale, :string
 
-      def process = ::AtlasEngine::AddressImporter::OpenAddress::GeoJsonImportLauncherJob.perform_later(
-        country_code:,
-        geojson_file_path: geojson_file_path.strip,
-        clear_records:,
-        locale:,
-      )
+      def process
+        ::AtlasEngine::AddressImporter::OpenAddress::GeoJsonImportLauncherJob.perform_later(
+          country_code:,
+          geojson_file_path: geojson_file_path.strip,
+          clear_records:,
+          locale:,
+        )
+      end
     end
   end
 end

--- a/db/data/country_profiles/default.yml
+++ b/db/data/country_profiles/default.yml
@@ -4,8 +4,8 @@ ingestion:
   correctors: {}
   settings: {}
   data_mapper: AtlasEngine::AddressValidation::Es::DataMappers::DefaultDataMapper
-  open_address:
-    feature_mapper: AtlasEngine::AddressImporter::OpenAddress::DefaultMapper
+  post_address_mapper:
+    open_address: AtlasEngine::AddressImporter::OpenAddress::DefaultMapper
 validation:
   enabled: false
   has_provinces: true

--- a/test/controllers/atlas_engine/country_imports_controller_test.rb
+++ b/test/controllers/atlas_engine/country_imports_controller_test.rb
@@ -29,7 +29,7 @@ module AtlasEngine
 
       assert_not country_import.reload.failed?
       assert_redirected_to(controller: "country_imports", action: "index")
-      assert_equal "Interruption of country import failed with StateMachines::InvalidTransition, "\
+      assert_equal "Interruption of country import failed with StateMachines::InvalidTransition, " \
         "Cannot transition state via :interrupt from :complete (Reason(s): State cannot transition via \"interrupt\")",
         flash[:alert]
     end

--- a/test/countries/atlas_engine/ch/country_profile_test.rb
+++ b/test/countries/atlas_engine/ch/country_profile_test.rb
@@ -18,9 +18,9 @@ module AtlasEngine
         assert_equal ["de", "fr", "it"], @profile.validation.index_locales
       end
 
-      test "ingestion open_address_feature_mapper is correct" do
+      test "ingestion post_address_mapper is correct for source open_address" do
         assert_equal AtlasEngine::Ch::AddressImporter::OpenAddress::Mapper,
-          @profile.ingestion.open_address_feature_mapper
+          @profile.ingestion.post_address_mapper("open_address")
       end
 
       test "#correctors value is correct for source open-address" do

--- a/test/countries/atlas_engine/si/country_profile_test.rb
+++ b/test/countries/atlas_engine/si/country_profile_test.rb
@@ -17,9 +17,9 @@ module AtlasEngine
           @profile.ingestion.correctors(source: "open_address")
       end
 
-      test "#feature_mapper value is correct for source open-address" do
+      test "#post_address_mapper value is correct for source open-address" do
         assert_equal AtlasEngine::Si::AddressImporter::OpenAddress::Mapper,
-          @profile.ingestion.open_address_feature_mapper
+          @profile.ingestion.post_address_mapper("open_address")
       end
 
       test "#validation_exclusions value is correct for city component" do

--- a/test/lib/validation_transcriber/address_parser_north_america_test.rb
+++ b/test/lib/validation_transcriber/address_parser_north_america_test.rb
@@ -767,8 +767,8 @@ module AtlasEngine
         actual = AddressParserNorthAmerica.new(address: address).parse
         assert(
           [expected].to_set.subset?(actual.to_set),
-          "For input #{address_specification.inspect},\n"\
-            "expected parsings to include #{expected.inspect},\n"\
+          "For input #{address_specification.inspect},\n" \
+            "expected parsings to include #{expected.inspect},\n" \
             "but got #{actual.inspect}.",
         )
       end

--- a/test/models/atlas_engine/country_profile_ingestion_subset_test.rb
+++ b/test/models/atlas_engine/country_profile_ingestion_subset_test.rb
@@ -5,15 +5,16 @@ require "test_helper"
 
 module AtlasEngine
   class CountryProfileIngestionSubsetTest < ActiveSupport::TestCase
-    test "#open_address_feature_mapper returns the DefaultMapper if no mapper is defined" do
+    test "#post_address_mapper returns the DefaultMapper if no mapper is defined" do
       profile = CountryProfile.for("AD")
       assert_equal AtlasEngine::AddressImporter::OpenAddress::DefaultMapper,
-        profile.ingestion.open_address_feature_mapper
+        profile.ingestion.post_address_mapper("open_address")
     end
 
-    test "#open_address_feature_mapper returns the correct feature mapper if defined" do
+    test "#post_address_mapper returns the correct feature mapper if defined" do
       profile = CountryProfile.for("AU")
-      assert_equal AtlasEngine::Au::AddressImporter::OpenAddress::Mapper, profile.ingestion.open_address_feature_mapper
+      assert_equal AtlasEngine::Au::AddressImporter::OpenAddress::Mapper,
+        profile.ingestion.post_address_mapper("open_address")
     end
   end
 end


### PR DESCRIPTION
## Context

Part 1 for https://github.com/Shopify/address/issues/2490

I'd like to introduce mapper classes that map GPC records to post address records, so that we can customize the mapping logic by country.

## Approach

Rearranged the storage of mappers in the country profiles so that they can eventually look something like this (like how we have stored the correctors):

```
ingestion:
  post_address_mapper:
    open_address: AtlasEngine::Ch::AddressImporter::OpenAddress::Mapper
    geo: Ch::AddressImporter::Geo::Mapper
```

## Testing
This does not change any behaviour.

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
