### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+nil.
+
+---
+
+[0.6.0] - 2024-02-26
+
 - Remove `Session` usage from `CandidateResult` and the unnecessary `CandidateTuple` object [#152](https://github.com/Shopify/atlas_engine/pull/152)
 - Refactor concern classes into concern builders, fixing the bug where some concern messages are not translated. [#156](https://github.com/Shopify/atlas_engine/pull/156)
 - Remove `Session` usage in `FullAddress` [#158](https://github.com/Shopify/atlas_engine/pull/158)
-
----
 
 [0.5.0] - 2024-02-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atlas_engine (0.5.0)
+    atlas_engine (0.6.0)
       annex_29
       elastic-transport
       elasticsearch-model

--- a/lib/atlas_engine/version.rb
+++ b/lib/atlas_engine/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module AtlasEngine
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
## Context

- Remove `Session` usage from `CandidateResult` and the unnecessary `CandidateTuple` object [#152](https://github.com/Shopify/atlas_engine/pull/152)
- Refactor concern classes into concern builders, fixing the bug where some concern messages are not translated. [#156](https://github.com/Shopify/atlas_engine/pull/156)
- Remove `Session` usage in `FullAddress` [#158](https://github.com/Shopify/atlas_engine/pull/158)

## Approach
<!-- Describe your solution, why this approach was chosen, and what the alternatives/impacts may be -->

...

## Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
