### PR TITLE
Update field_names to include only problematic address field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Log elasticsearch errors and push elasticsearch error metrics to statsd [#171](https://github.com/Shopify/atlas_engine/pull/171)
+- Update validation concern field field_names to contain just the problematic address field [#173](https://github.com/Shopify/atlas_engine/pull/173)
 
 ---
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/country/valid_for_zip.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/country/valid_for_zip.rb
@@ -28,7 +28,7 @@ module AtlasEngine
             sig { params(suggestion: Suggestion).returns(Concern) }
             def build_concern(suggestion)
               Concern.new(
-                field_names: [:country, :zip],
+                field_names: [:country],
                 code: :country_invalid_for_zip,
                 type: T.must(Concern::TYPES[:error]),
                 type_level: 1,

--- a/app/models/atlas_engine/address_validation/validators/predicates/province/valid_for_country.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/province/valid_for_country.rb
@@ -24,7 +24,7 @@ module AtlasEngine
             sig { returns(Concern) }
             def build_concern
               Concern.new(
-                field_names: [:province, :country],
+                field_names: [:province],
                 code: :province_invalid,
                 type: T.must(Concern::TYPES[:error]),
                 type_level: 3,

--- a/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1.rb
@@ -24,7 +24,7 @@ module AtlasEngine
             sig { returns(Concern) }
             def build_concern
               Concern.new(
-                field_names: [:address1, :country],
+                field_names: [:address1],
                 code: :missing_building_number,
                 type: T.must(Concern::TYPES[:warning]),
                 type_level: 1,

--- a/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2.rb
@@ -22,7 +22,7 @@ module AtlasEngine
             sig { returns(Concern) }
             def build_concern
               Concern.new(
-                field_names: [:address1, :address2, :country],
+                field_names: [:address1, :address2],
                 code: :missing_building_number,
                 type: T.must(Concern::TYPES[:warning]),
                 type_level: 3,

--- a/app/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_country.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_country.rb
@@ -26,7 +26,7 @@ module AtlasEngine
             sig { returns(Concern) }
             def build_concern
               Concern.new(
-                field_names: [:zip, :country],
+                field_names: [:zip],
                 code: :zip_invalid_for_country,
                 type: T.must(Concern::TYPES[:error]),
                 type_level: 3,

--- a/app/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_province.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_province.rb
@@ -29,7 +29,7 @@ module AtlasEngine
             sig { returns(Concern) }
             def build_concern
               Concern.new(
-                field_names: [:zip, :country, :province],
+                field_names: [:zip],
                 code: :zip_invalid_for_province,
                 type: T.must(Concern::TYPES[:error]),
                 type_level: 3,

--- a/test/models/atlas_engine/address_validation/validators/predicates/country/valid_for_zip_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/predicates/country/valid_for_zip_test.rb
@@ -19,7 +19,7 @@ module AtlasEngine
 
               expected_concern =
                 {
-                  field_names: [:country, :zip],
+                  field_names: [:country],
                   message: I18n.t("worldwide.GB.addresses.zip.errors.invalid_for_country"),
                   code: :country_invalid_for_zip,
                   type: "error",

--- a/test/models/atlas_engine/address_validation/validators/predicates/province/valid_for_country_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/predicates/province/valid_for_country_test.rb
@@ -67,7 +67,7 @@ module AtlasEngine
 
               expected_concern =
                 {
-                  field_names: [:province, :country],
+                  field_names: [:province],
                   message: I18n.t("worldwide.CA.addresses.province.errors.blank"),
                   code: :province_invalid,
                   type: "error",

--- a/test/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2_test.rb
@@ -35,7 +35,7 @@ module AtlasEngine
 
               expected_concern =
                 {
-                  field_names: [:address1, :address2, :country],
+                  field_names: [:address1, :address2],
                   message: "Add a building number if you have one.",
                   code: :missing_building_number,
                   type: "warning",
@@ -71,7 +71,7 @@ module AtlasEngine
 
               expected_concern =
                 {
-                  field_names: [:address1, :address2, :country],
+                  field_names: [:address1, :address2],
                   message: "Add a building number if you have one.",
                   code: :missing_building_number,
                   type: "warning",

--- a/test/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_test.rb
@@ -46,7 +46,7 @@ module AtlasEngine
               concern = BuildingNumberInAddress1.new(field: :address1, address: address).evaluate
 
               expected_concern = {
-                field_names: [:address1, :country],
+                field_names: [:address1],
                 message: "Add a building number if you have one.",
                 code: :missing_building_number,
                 type: "warning",

--- a/test/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_country_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_country_test.rb
@@ -35,7 +35,7 @@ module AtlasEngine
               concern = ValidForCountry.new(field: :zip, address: address).evaluate
 
               expected_concern = {
-                field_names: [:zip, :country],
+                field_names: [:zip],
                 code: :zip_invalid_for_country,
                 message: I18n.t(
                   "worldwide._default.addresses.zip.errors.invalid_for_country",
@@ -60,7 +60,7 @@ module AtlasEngine
                 concern = ValidForCountry.new(field: :zip, address: address).evaluate
 
                 expected_concern = {
-                  field_names: [:zip, :country],
+                  field_names: [:zip],
                   code: :zip_invalid_for_country,
                   message: I18n.t("worldwide._default.addresses.zip.errors.invalid_for_country", country: "日本"),
                   type: "error",

--- a/test/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_province_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/predicates/zip/valid_for_province_test.rb
@@ -35,7 +35,7 @@ module AtlasEngine
               concern = ValidForProvince.new(field: :zip, address: address).evaluate
 
               expected_concern = {
-                field_names: [:zip, :country, :province],
+                field_names: [:zip],
                 message: I18n.t(
                   "worldwide._default.addresses.zip.errors.invalid_for_province",
                   province: Worldwide.region(code: "CA").zone(code: "ON").full_name,
@@ -61,7 +61,7 @@ module AtlasEngine
                 concern = ValidForProvince.new(field: :zip, address: address).evaluate
 
                 expected_concern = {
-                  field_names: [:zip, :country, :province],
+                  field_names: [:zip],
                   message: I18n.t(
                     "worldwide._default.addresses.zip.errors.invalid_for_province",
                     province: Worldwide.region(code: "KR").zone(code: "KR-11").full_name,


### PR DESCRIPTION
## Context
Related to https://github.com/Shopify/address/issues/2406

Our clients use the `fieldNames` field on our validation concerns to determine what address field(s) to associate with the concern message. However, some of our concerns include all relevant address fields in `fieldNames`, which has resulted in some concern messages being displayed on multiple fields (see issue). 

## Approach

Update `fieldNames` to only include the problematic field(s).

## Testing

This does not affect checkout because [we only use the first item](https://github.com/Shopify/checkout-web/blob/6f81ba7af2ce9c3238e31c9601ba84d8932879cb/app/foundation/ShopPayExternal/hooks/addresses/useStreetLevelAddressValidation.ts#L127) in the `field_names` array when deciding under which address field to display the suggestion.

The [issue](https://github.com/Shopify/address/issues/2406) in the payment profile assessment form has already been resolved on their end (I was not able to reproduce the behaviour shown in the screenshot). 

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
