### PR TITLE
added address parser and city exclusion for gg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Add address parser and city exclusion for Guernsey [#184](https://github.com/Shopify/atlas_engine/pull/184)
 - Log elasticsearch errors and push elasticsearch error metrics to statsd [#171](https://github.com/Shopify/atlas_engine/pull/171)
 - Update validation concern field field_names to contain just the problematic address field [#173](https://github.com/Shopify/atlas_engine/pull/173)
 

--- a/app/countries/atlas_engine/gg/address_validation/validators/full_address/exclusions/city.rb
+++ b/app/countries/atlas_engine/gg/address_validation/validators/full_address/exclusions/city.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Gg
+    module AddressValidation
+      module Validators
+        module FullAddress
+          module Exclusions
+            class City <
+              AtlasEngine::AddressValidation::Validators::FullAddress::Exclusions::ExclusionBase
+              extend T::Sig
+              class << self
+                sig do
+                  override.params(
+                    candidate: AtlasEngine::AddressValidation::Candidate,
+                    address_comparison: AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
+                  )
+                    .returns(T::Boolean)
+                end
+                def apply?(candidate, address_comparison)
+                  # If the candidate city is already present in the parsings
+                  address_comparison.parsings.parsings.pluck(:city)&.include?(candidate.component(:city)&.value&.first)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/countries/atlas_engine/gg/country_profile.yml
+++ b/app/countries/atlas_engine/gg/country_profile.yml
@@ -3,5 +3,9 @@ validation:
   enabled: true
   default_matching_strategy: es
   has_provinces: false
+  address_parser: AtlasEngine::Gg::ValidationTranscriber::AddressParser
   restrictions:
     - class: AtlasEngine::Gg::AddressValidation::Validators::FullAddress::Restrictions::UnsupportedCity
+  exclusions:
+    city:
+      - AtlasEngine::Gg::AddressValidation::Validators::FullAddress::Exclusions::City

--- a/app/countries/atlas_engine/gg/validation_transcriber/address_parser.rb
+++ b/app/countries/atlas_engine/gg/validation_transcriber/address_parser.rb
@@ -1,0 +1,43 @@
+# typed: true
+# frozen_string_literal: true
+
+module AtlasEngine
+  module Gg
+    module ValidationTranscriber
+      class AddressParser < AtlasEngine::ValidationTranscriber::AddressParserBase
+        private
+
+        CITY = %r{
+          (?<city>
+            st\.?\s?saviour[']?[s]?|
+            st\.?\s?sampson[']?[s]?|
+            st\.?\s?andrew[']?[s]?|
+            st\.?\s?martin[']?[s]?|
+            st\.?\s?peter[']?[s]?\s?port|
+            st\.?\s?peter[']?[s]?|
+            st\.?\s?pierre\s?du\s?bois|
+            vale|
+            torteval|
+            castel|
+            forest
+          )
+        }ix
+
+        sig { returns(T::Array[Regexp]) }
+        def country_regex_formats
+          @country_regex_formats ||= [
+            /^#{BUILDING_NAME},\s+#{CITY}$/,
+            /^#{BUILDING_NAME},\s+#{STREET_NO_COMMAS},\s+#{CITY}$/,
+            /^#{BUILDING_NAME},\s+#{STREET_NO_COMMAS}$/,
+            /^#{NUMERIC_ONLY_BUILDING_NUM}?\s+#{STREET_NO_COMMAS},\s+#{CITY}$/,
+            /^#{UNIT_TYPE}\s+#{UNIT_NUM_NO_HYPHEN},\s+#{BUILDING_NAME},\s+#{CITY}$/,
+            /^#{CITY}$/,
+            /^#{NUMERIC_ONLY_BUILDING_NUM}?\s+#{STREET_NO_COMMAS}$/,
+            /^#{BUILDING_NAME}$/,
+            /^#{STREET_NO_COMMAS}$/,
+          ]
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/gg/address_validation/validators/full_address/exclusions/city_test.rb
+++ b/test/countries/atlas_engine/gg/address_validation/validators/full_address/exclusions/city_test.rb
@@ -1,0 +1,82 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+require "models/atlas_engine/address_validation/address_validation_test_helper"
+
+module AtlasEngine
+  module Gg
+    module AddressValidation
+      module Validators
+        module FullAddress
+          module Exclusions
+            class CityTest < ActiveSupport::TestCase
+              include AtlasEngine::AddressValidation::AddressValidationTestHelper
+
+              test "#apply? returns true when candidate city is present in sesssion address components" do
+                address = build_address(
+                  address1: "43 Mount Row, St. Peter Port",
+                  city: "",
+                  country_code: "GG",
+                  zip: "GY1 1NU",
+                )
+
+                candidate_address = candidate(
+                  building_num: "43",
+                  street: "Mount Row",
+                  city: ["St. Peter Port"],
+                  country_code: "GG",
+                  zip: "GY1 1NU",
+                )
+
+                comparison = mock_address_comparison(address, "St. Peter Port", "St. Peter Port")
+
+                assert City.apply?(candidate_address, comparison)
+              end
+
+              test "#apply? returns false when candidate city is NOTpresent in sesssion address components" do
+                address = build_address(
+                  address1: "43 Mount Row",
+                  city: "St. Peter Port",
+                  country_code: "GG",
+                  zip: "GY1 1NU",
+                )
+
+                candidate_address = candidate(
+                  building_num: "43",
+                  street: "Mount Row",
+                  city: ["St. Peter Port"],
+                  country_code: "GG",
+                  zip: "GY1 1NU",
+                )
+
+                comparison = mock_address_comparison(address, "St. Peter Port", "St. Peter Port")
+
+                assert_not City.apply?(candidate_address, comparison)
+              end
+
+              def mock_address_comparison(session_address, given_city, candidate_city)
+                given_sequence = AtlasEngine::AddressValidation::Token::Sequence.from_string(given_city)
+                candidate_sequence = AtlasEngine::AddressValidation::Token::Sequence.from_string(candidate_city)
+                city_comparison = AtlasEngine::AddressValidation::Token::Sequence::Comparator.new(
+                  left_sequence: given_sequence,
+                  right_sequence: candidate_sequence,
+                ).compare
+
+                address_comparison = typed_mock(
+                  AtlasEngine::AddressValidation::Validators::FullAddress::AddressComparison,
+                )
+                address_comparison.stubs(:city_comparison).returns(city_comparison)
+
+                parsings = parsings_for(session_address)
+                address_comparison.stubs(:parsings).returns(parsings)
+                address_comparison.stubs(:address).returns(session_address)
+                address_comparison
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/countries/atlas_engine/gg/validation_transcriber/address_parser_test.rb
+++ b/test/countries/atlas_engine/gg/validation_transcriber/address_parser_test.rb
@@ -1,0 +1,122 @@
+# typed: true
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AtlasEngine
+  module Gg
+    module ValidationTranscriber
+      class AddressParserTest < ActiveSupport::TestCase
+        include ValidationTranscriber
+
+        test "CountryProfile for GG loads the correct address parser" do
+          assert_equal(AddressParser, CountryProfile.for("GG").validation.address_parser)
+        end
+
+        test "Parses one line Guernsey addresses" do
+          [
+            [
+              :gg,
+              "La Boue Farmhouse",
+              [{ building_name: "La Boue Farmhouse" }],
+            ],
+            [
+              :gg,
+              "Donegal, Pleinmont Road, St Peter's",
+              [{ building_name: "Donegal", street: "Pleinmont Road", city: "St Peter's" }],
+            ],
+            [
+              :gg,
+              "Apartment 15, La Charrotterie Mills, St Peter's Port",
+              [{
+                unit_type: "Apartment",
+                unit_num: "15",
+                building_name: "La Charrotterie Mills",
+                city: "St Peter's Port",
+              }],
+            ],
+            [
+              :gg,
+              "7 Victoria Street",
+              [{ street: "Victoria Street", building_num: "7" }],
+            ],
+            [
+              :gg,
+              "La Bouvee Farm Cottage La Bouvee, St. Martins",
+              [{ building_name: "La Bouvee Farm Cottage La Bouvee", city: "St. Martins" }],
+            ],
+          ].each do |country_code, address1, expected|
+            check_parsing(country_code, address1, nil, expected)
+          end
+        end
+
+        test "Two line Guernsey addresses" do
+          [
+            [
+              :gg,
+              "Lavender Lodge",
+              "St Peter port",
+              [
+                { building_name: "Lavender Lodge" },
+                { city: "St Peter port" },
+              ],
+            ],
+            [
+              :gg,
+              "Menerbes, La Grande Rue",
+              "St. Saviour",
+              [
+
+                { city: "St. Saviour" },
+                { building_name: "Menerbes", street: "La Grande Rue" },
+
+              ],
+            ],
+            [
+              :gg,
+              "Les Sages de Bas",
+              "Les Sages",
+              [
+
+                { building_name: "Les Sages de Bas" },
+                { street: "Les Sages" },
+
+              ],
+            ],
+            [
+              :gg,
+              "19 Victoria Road",
+              "St Peter Port",
+              [
+
+                { building_num: "19", street: "Victoria Road" },
+                { city: "St Peter Port" },
+
+              ],
+            ],
+          ].each do |country_code, address1, address2, expected|
+            check_parsing(country_code, address1, address2, expected)
+          end
+        end
+
+        private
+
+        def check_parsing(country_code, address1, address2, expected, components = nil)
+          components ||= {}
+          components.merge!(country_code: country_code.to_s.upcase, address1: address1, address2: address2)
+          address = AtlasEngine::AddressValidation::Address.new(**components)
+
+          actual = AddressParser.new(address: address).parse
+
+          assert(
+            expected.to_set.subset?(actual.to_set),
+            "For input ( address1: #{address1.inspect}, address2: #{address2.inspect} )\n\n " \
+              "#{expected.inspect} \n\n" \
+              "Must be included in: \n\n" \
+              "#{actual.inspect}",
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
https://github.com/Shopify/address/issues/2379
## Approach

Added an address parser for guernsey. 

1. Determined the common address formats and added them to the parser
2. There are only 10 official cities in Guernsey so I created a regex for them so that the parser can detect them. 

There is common case where people put their city (called parishes in Guernsey) in address1 or address2. I added an exclusion to apply when the city is present in address1 or address2, so we don't have unnecessary concerns flagged. 



## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
