### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+nil.
+
+---
+
+[0.8.0] - 2024-04-02
+
 - Add french city aliases to Guernsey address parser [#205](https://github.com/Shopify/atlas_engine/pull/205)
 - Centralize ruby version [#200](https://github.com/Shopify/atlas_engine/pull/200)
 - Add city corrector for Guernsey and synonyms [#192](https://github.com/Shopify/atlas_engine/pull/192)
-
----
 
 [0.7.0] - 2024-03-13
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atlas_engine (0.7.0)
+    atlas_engine (0.8.0)
       annex_29
       elastic-transport
       elasticsearch-model
@@ -378,6 +378,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/atlas_engine/version.rb
+++ b/lib/atlas_engine/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module AtlasEngine
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
## Context

- Add french city aliases to Guernsey address parser [#205](https://github.com/Shopify/atlas_engine/pull/205)
- Centralize ruby version [#200](https://github.com/Shopify/atlas_engine/pull/200)
- Add city corrector for Guernsey and synonyms [#192](https://github.com/Shopify/atlas_engine/pull/192)

## Approach

## Testing

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
