### PR TITLE
Remove GCS comment

### DIFF
--- a/app/tasks/maintenance/atlas_engine/geo_json_import_task.rb
+++ b/app/tasks/maintenance/atlas_engine/geo_json_import_task.rb
@@ -12,9 +12,6 @@ module Maintenance
       # ISO3166 two-letter country code.
       attribute :country_code, :string
       validates :country_code, presence: true
-      # Filename to import. When running in staging or production, the worker expects to find
-      # this file in the relevant GCS bucket, configured in `config/storage/{environment}.yml`
-      # It must be placed under `openaddress/` with the same filename.
       attribute :geojson_file_path, :string
       attribute :locale, :string
 


### PR DESCRIPTION
## Context
<!-- Link relevant issues or provide a TL;DR -->

* GCS is not used in this ingestion flow for OpenAddresses - removing the comment.

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [ ] Added Sorbet signatures to new methods I've introduced 
- [ ] Commits squashed 
