### PR TITLE
GraphiQL - Sprockets off development environment installation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,11 @@ gemspec
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+# For loading the /graphiql assests
+gem "sprockets-rails"
+
 group :development, :test do
   gem "dotenv-rails", require: "dotenv/rails-now"
-  # For loading the /graphiql assests
-  gem "sprockets-rails"
 
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
## Context
<!-- Link relevant issues or provide a TL;DR -->

* Investigating a bug where parent applications leveraging AtlasEngines GraphiQL installation off of development are unable to receive assets

## Approach
<!-- Describe your solution, why this approach was chosen, and what the alternatives/impacts may be -->

* Install sprockets off of development as this is used to serve GraphiQL assets

## Checklist

- [ ] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
