### PR TITLE
Release 0.8.1; patches bug where province concern message is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-
-nil.
+- nil.
 
 ---
+
+[0.8.1] - 2024-05-10
+
+- Fix bug where province_inconsistent concern is returned without a message [#259](https://github.com/Shopify/atlas_engine/pull/259)
+
 
 [0.8.0] - 2024-04-02
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    atlas_engine (0.8.0)
+    atlas_engine (0.8.1)
       annex_29
       elastic-transport
       elasticsearch-model
@@ -99,7 +99,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    annex_29 (0.1.1)
+    annex_29 (0.2.0)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
@@ -138,7 +138,7 @@ GEM
       faraday (>= 1, < 3)
       multi_json
     erubi (1.12.0)
-    factory_bot (6.4.5)
+    factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
@@ -153,7 +153,7 @@ GEM
       activesupport (>= 6.1)
     graphiql-rails (1.10.0)
       railties
-    graphql (2.3.2)
+    graphql (2.3.3)
       base64
     hashdiff (1.1.0)
     hashie (5.0.0)
@@ -183,8 +183,8 @@ GEM
       job-iteration (>= 1.3.6)
       railties (>= 6.0)
       zeitwerk (>= 2.6.2)
-    marcel (1.0.2)
-    method_source (1.0.0)
+    marcel (1.0.4)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     minitest-distributed (0.2.10)
@@ -203,17 +203,17 @@ GEM
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
-    net-imap (0.4.10)
+    net-imap (0.4.11)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0.1)
+    net-smtp (0.5.0)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.7.0)
+    nio4r (2.7.3)
     nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.4-x86_64-linux)
@@ -223,7 +223,7 @@ GEM
       ast (~> 2.4.1)
       racc
     phonelib (0.8.8)
-    prism (0.28.0)
+    prism (0.29.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -232,9 +232,9 @@ GEM
       pry (>= 0.13, < 0.15)
     psych (5.1.2)
       stringio
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     racc (1.7.3)
-    rack (3.0.10)
+    rack (3.0.11)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -278,15 +278,15 @@ GEM
       sorbet-runtime (>= 0.5.9204)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    redis (5.0.8)
-      redis-client (>= 0.17.0)
-    redis-client (0.19.1)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.1)
       connection_pool
     regexp_parser (2.9.0)
-    reline (0.5.5)
+    reline (0.5.6)
       io-console (~> 0.5)
     rexml (3.2.6)
-    rubocop (1.63.4)
+    rubocop (1.63.5)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -314,14 +314,14 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sorbet (0.5.11370)
-      sorbet-static (= 0.5.11370)
-    sorbet-runtime (0.5.11370)
-    sorbet-static (0.5.11370-universal-darwin)
-    sorbet-static (0.5.11370-x86_64-linux)
-    sorbet-static-and-runtime (0.5.11370)
-      sorbet (= 0.5.11370)
-      sorbet-runtime (= 0.5.11370)
+    sorbet (0.5.11371)
+      sorbet-static (= 0.5.11371)
+    sorbet-runtime (0.5.11371)
+    sorbet-static (0.5.11371-universal-darwin)
+    sorbet-static (0.5.11371-x86_64-linux)
+    sorbet-static-and-runtime (0.5.11371)
+      sorbet (= 0.5.11371)
+      sorbet-runtime (= 0.5.11371)
     spoom (1.3.2)
       erubi (>= 1.10.0)
       prism (>= 0.19.0)

--- a/app/models/atlas_engine/address_validation/validators/full_address/unmatched_field_concern_builder.rb
+++ b/app/models/atlas_engine/address_validation/validators/full_address/unmatched_field_concern_builder.rb
@@ -8,7 +8,7 @@ module AtlasEngine
         class UnmatchedFieldConcernBuilder
           extend T::Sig
           include ConcernFormatter
-          attr_reader :address, :component, :matched_components, :unmatched_field
+          attr_reader :address, :unmatched_component, :matched_components, :unmatched_field
 
           COMPONENTS_TO_LABELS = {
             zip: "ZIP",
@@ -31,9 +31,9 @@ module AtlasEngine
           end
           def initialize(unmatched_component, matched_components, address, unmatched_field = nil)
             @address = address
-            @component = unmatched_component
+            @unmatched_component = unmatched_component
             @matched_components = matched_components
-            @unmatched_field = unmatched_field
+            @unmatched_field = unmatched_field || unmatched_component
           end
 
           sig do
@@ -61,7 +61,7 @@ module AtlasEngine
 
           sig { returns(Symbol) }
           def code
-            "#{shortened_component_name}_inconsistent".to_sym
+            "#{unmatched_component_name}_inconsistent".to_sym
           end
 
           sig { returns(T::Array[Symbol]) }
@@ -69,21 +69,14 @@ module AtlasEngine
             [field_name]
           end
 
-          sig { returns(T::Array[String]) }
-          def valid_address_component_values
-            matched_components.last(2).map do |component|
-              component == :province_code ? province_name : address[component]
-            end
-          end
-
           sig { returns(Symbol) }
-          def shortened_component_name
-            SHORTENED_COMPONENT_NAMES[component] || component
+          def unmatched_component_name
+            SHORTENED_COMPONENT_NAMES[unmatched_component] || unmatched_component
           end
 
           sig { returns(Symbol) }
           def field_name
-            unmatched_field || shortened_component_name
+            SHORTENED_COMPONENT_NAMES[unmatched_field] || unmatched_field
           end
         end
       end

--- a/lib/atlas_engine/version.rb
+++ b/lib/atlas_engine/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module AtlasEngine
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/test/models/atlas_engine/address_validation/validators/full_address/candidate_result_test.rb
+++ b/test/models/atlas_engine/address_validation/validators/full_address/candidate_result_test.rb
@@ -224,10 +224,12 @@ module AtlasEngine
             province_concern = result.concerns.find { |c| :province_inconsistent == c.code }
             assert_not_nil province_concern
             assert_equal result.suggestions.map(&:id), province_concern.suggestion_ids
+            assert_equal "Province may be incorrect.", province_concern.message
 
             zip_concern = result.concerns.find { |c| :zip_inconsistent == c.code }
             assert_not_nil zip_concern
             assert_equal result.suggestions.map(&:id), zip_concern.suggestion_ids
+            assert_equal "Postal code may be incorrect.", zip_concern.message
           end
 
           test "adds invalid zip concern without suggestions when ConcernBuilder.should_suggest? is false and /


### PR DESCRIPTION
## Context

In some cases, the `province_inconsistent` concern is generated without an error message 😱 

![Screenshot 2024-05-10 at 2 32 39 PM](https://github.com/Shopify/atlas_engine/assets/145736265/bf789f2b-c1ca-499b-b638-b41dc1d660a9)

closes https://github.com/Shopify/address/issues/2580


## Approach
The field name `province_code` needs to map to the shortened form `province` when loading the error messages.

Added a test to ensure the message is loaded, and fixed the logic to map the field name to the shortened form when applicable. 

Released a new patch version, `0.8.1`

## Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
