### PR TITLE
Break from validation pipeline if country code is invalid 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Security in case of vulnerabilities.
 
 ## [Unreleased]
-- nil.
+- Break from validation pipeline if country code is invalid[#261](https://github.com/Shopify/atlas_engine/pull/261)
 
 ---
 

--- a/app/models/atlas_engine/address_validation/validator.rb
+++ b/app/models/atlas_engine/address_validation/validator.rb
@@ -114,6 +114,8 @@ module AtlasEngine
         local_concerns = {}
         cache = Validators::Predicates::Cache.new(pipeline_address)
         @predicate_pipeline.pipeline.each do |config|
+          break if local_concerns[:country].present?
+
           local_concerns[config.field] = [] if local_concerns[config.field].nil?
           next if local_concerns[config.field].present?
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/city/present.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/city/present.rb
@@ -9,7 +9,6 @@ module AtlasEngine
           class Present < Predicate
             sig { override.returns(T.nilable(Concern)) }
             def evaluate
-              return unless @cache.country.country?
               return if @cache.country.field(key: :city).autofill(locale: :en).present?
 
               build_concern if @address.city.blank?

--- a/app/models/atlas_engine/address_validation/validators/predicates/no_emojis.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/no_emojis.rb
@@ -8,8 +8,6 @@ module AtlasEngine
         class NoEmojis < Predicate
           sig { override.returns(T.nilable(Concern)) }
           def evaluate
-            return unless @cache.country.country?
-
             build_concern if contains_blocked_codepoints?(address.send(@field))
           end
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/no_html_tags.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/no_html_tags.rb
@@ -8,8 +8,6 @@ module AtlasEngine
         class NoHtmlTags < Predicate
           sig { override.returns(T.nilable(Concern)) }
           def evaluate
-            return unless @cache.country.country?
-
             build_concern if contains_html_tags(address.send(@field))
           end
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/no_url.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/no_url.rb
@@ -8,8 +8,6 @@ module AtlasEngine
         class NoUrl < Predicate
           sig { override.returns(T.nilable(Concern)) }
           def evaluate
-            return unless @cache.country.country?
-
             build_concern if contains_url(address.send(@field))
           end
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/not_exceed_max_length.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/not_exceed_max_length.rb
@@ -9,8 +9,6 @@ module AtlasEngine
           MAX_COMPONENT_LENGTH = 255
           sig { override.returns(T.nilable(Concern)) }
           def evaluate
-            return unless @cache.country.country?
-
             build_concern if address.send(@field).to_s.length > MAX_COMPONENT_LENGTH
           end
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/phone/valid.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/phone/valid.rb
@@ -9,8 +9,6 @@ module AtlasEngine
           class Valid < Predicate
             sig { override.returns(T.nilable(Concern)) }
             def evaluate
-              return if @address.country_code.blank?
-              return unless @cache.country.country?
               return if @address.phone.blank?
 
               phone = Worldwide::Phone.new(number: @address.phone, country_code: @address.country_code)

--- a/app/models/atlas_engine/address_validation/validators/predicates/province/exists.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/province/exists.rb
@@ -9,7 +9,6 @@ module AtlasEngine
           class Exists < Predicate
             sig { override.returns(T.nilable(Concern)) }
             def evaluate
-              return unless @cache.country.country?
               return if address.province_code.present? ||
                 country_has_no_provinces ||
                 @cache.country.province_optional?

--- a/app/models/atlas_engine/address_validation/validators/predicates/province/valid_for_country.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/province/valid_for_country.rb
@@ -9,7 +9,6 @@ module AtlasEngine
           class ValidForCountry < Predicate
             sig { override.returns(T.nilable(Concern)) }
             def evaluate
-              return unless @cache.country.country?
               return if address.province_code.blank?
               return if @cache.country.zones.none?(&:province?)
               return if @cache.country.hide_provinces_from_addresses

--- a/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1.rb
@@ -9,8 +9,6 @@ module AtlasEngine
           class BuildingNumberInAddress1 < Predicate
             sig { override.returns(T.nilable(Concern)) }
             def evaluate
-              return unless @cache.country.country?
-
               return unless @cache.country.building_number_required
               return if @cache.country.building_number_may_be_in_address2
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/street/building_number_in_address1_or_address2.rb
@@ -9,7 +9,6 @@ module AtlasEngine
           class BuildingNumberInAddress1OrAddress2 < Predicate
             sig { override.returns(T.nilable(Concern)) }
             def evaluate
-              return unless @cache.country.country?
               return unless @cache.country.building_number_required
               return unless @cache.country.building_number_may_be_in_address2
               return if contains_number?(T.must(@address.address1)) || contains_number?(@address.address2)

--- a/app/models/atlas_engine/address_validation/validators/predicates/street/present.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/street/present.rb
@@ -9,8 +9,6 @@ module AtlasEngine
           class Present < Predicate
             sig { override.returns(T.nilable(Concern)) }
             def evaluate
-              return unless @cache.country.country?
-
               build_concern if @address.address1.blank?
             end
 

--- a/app/models/atlas_engine/address_validation/validators/predicates/zip/zip_base.rb
+++ b/app/models/atlas_engine/address_validation/validators/predicates/zip/zip_base.rb
@@ -11,7 +11,6 @@ module AtlasEngine
 
             sig { returns(T.nilable(T::Boolean)) }
             def concerning?
-              return false unless @cache.country.country?
               return false unless @cache.country.has_zip?
               return false unless @cache.country.zip_required?
 

--- a/test/models/atlas_engine/address_validation/validator_test.rb
+++ b/test/models/atlas_engine/address_validation/validator_test.rb
@@ -268,12 +268,12 @@ module AtlasEngine
         assert_equal(:zip_invalid_for_province, result[:concerns].first[:code])
       end
 
-      test "when concern on country code, does not run remaining predicates" do
+      test "when invalid country code, does not run remaining predicates" do
         address = build_address(
-          address1: nil,
+          address1: "1 2 3 4 5 6 7 8 9 8 7 6 5 4 3 2 1 2 3 4 5 6 7 8 9",
           city: "Vancouver",
           province_code: "BC",
-          zip: "M9A 4Y8",
+          zip: "V6K 4Y8",
           country_code: "xx",
         )
 

--- a/test/models/atlas_engine/address_validation/validator_test.rb
+++ b/test/models/atlas_engine/address_validation/validator_test.rb
@@ -267,6 +267,22 @@ module AtlasEngine
         assert result[:concerns].present?
         assert_equal(:zip_invalid_for_province, result[:concerns].first[:code])
       end
+
+      test "when concern on country code, does not run remaining predicates" do
+        address = build_address(
+          address1: nil,
+          city: "Vancouver",
+          province_code: "BC",
+          zip: "M9A 4Y8",
+          country_code: "xx",
+        )
+
+        result = Validator.new(address: address, matching_strategy: MatchingStrategies::Local).run
+        result = result.attributes
+
+        assert_equal 1, result[:concerns].size
+        assert_equal(:country_blank, result[:concerns].first[:code])
+      end
     end
   end
 end


### PR DESCRIPTION
## Context
A validation request with address1/2 exceeding max token count **and** an invalid country code returns a NoMethodError. 

The country is required in each predicate class when generating the localized concern message. Almost every predicate class includes a check to ensure the country is valid.

One predicate, `NotExceedMaxTokenCount`, slipped through the cracks, which is resulting in a NoMethodError raised when the object attempts to load the country error strings here, 
https://github.com/Shopify/atlas_engine/blob/44a7b5c6acca63866686818396d2f4a105701839/app/models/atlas_engine/address_validation/validators/predicates/not_exceed_max_token_count.rb#L27-L30


part of the work for https://github.com/Shopify/address/issues/2516

## Approach
Instead of checking for country validity on each predicate, this PR introduces logic to terminate the pipeline executor when a country concern is present. 

This is a special case for country; the country is needed to generate the proper concern messages. Without the country present, the concern message will not be localized to the region. 

## Testing
**before**
<img width="1220" alt="Screenshot 2024-05-13 at 4 18 16 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/01e40c2c-c0dd-4360-9486-4e620f8741bd">

**after**
<img width="917" alt="Screenshot 2024-05-13 at 4 16 29 PM" src="https://github.com/Shopify/atlas_engine/assets/145736265/65ee1632-c187-4037-be57-b54ae7683764">


...

## Checklist

- [x] I have added a CHANGELOG entry for this change (or determined that it isn't needed)
- [x] Added Sorbet signatures to new methods I've introduced 
- [x] Commits squashed 
